### PR TITLE
possible bugfix in `Controller::LevelIter`

### DIFF
--- a/include/pfasst/controller.hpp
+++ b/include/pfasst/controller.hpp
@@ -104,8 +104,8 @@ namespace pfasst
           bool operator>=(LevelIter i) { return level >= i.level; }
           bool operator< (LevelIter i) { return level <  i.level; }
           bool operator> (LevelIter i) { return level >  i.level; }
-          LevelIter operator- (int i) { return LevelIter(level - 1, ts); }
-          LevelIter operator+ (int i) { return LevelIter(level + 1, ts); }
+          LevelIter operator- (size_t i) { return LevelIter(level - i, ts); }
+          LevelIter operator+ (size_t i) { return LevelIter(level + i, ts); }
           void operator++() { level++; }
           void operator--() { level--; }
       };


### PR DESCRIPTION
Shouldn't the `LevelIter`'s `operator-(i)` and `operator+(i)` increment or decrement the iterator by the given size?

ToDo: add assertion on validity of new index
