### PR TITLE
adding basic profiler support and test coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /doc/build
 /build*
 /dist
+/coverage
+*.info
 
 # Created by http://www.gitignore.io
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,6 @@ set(pfasst_DEPENDEND_LIBS)
 
 if(pfasst_BUILD_TESTS)
     enable_testing()
-    if(pfasst_WITH_GCC_PROF)
-        add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-ftest-coverage")
-    endif(pfasst_WITH_GCC_PROF)
 endif(pfasst_BUILD_TESTS)
 
 # Add / include 3rd-party libraries
@@ -108,6 +105,7 @@ if(pfasst_BUILD_TESTS)
 endif()
 message(STATUS "********************************************************************************")
 
+message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
 message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "C++ Compiler Names: ${CMAKE_CXX_COMPILER_NAMES}")
 message(STATUS "C++ Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+basepath=`pwd`
+
+function print_help {
+  echo "#######################################################################"
+  echo "###               Generation of Test Coverage Report                ###"
+  echo "#                                                                     #"
+  echo "# This only works for builds made with GCC and the following CMake    #"
+  echo "# variables:                                                          #"
+  echo "#   -Dpfasst_WITH_GCC_PROF=ON -Dpfasst_BUILD_TESTS=ON                 #"
+  echo "#                                                                     #"
+  echo "# First (and only) parameter must be the name of the build directory  #"
+  echo "#                                                                     #"
+  echo "# Example:                                                            #"
+  echo "#   ./generate_coverage.sh build_gcc                                  #"
+  echo "#                                                                     #"
+  echo "#######################################################################"
+  return 0
+}
+
+
+if [[ $# -ne 1 ]]
+then
+  print_help
+  echo "ERROR: Please name the build directory as the first parameter."
+  exit -1
+fi
+
+builddir=${1}
+cd ${builddir}
+
+rm -rf ${basepath}/coverage
+mkdir -p ${basepath}/coverage
+
+for testdir in `find ${basepath}/${builddir} -type d | grep -o 'tests/.*/.*\dir'`
+do
+  testname=`expr "$testdir" : '.*\(test_[a-zA-Z\-_]*\)\.dir'`
+  echo "Gathering Coverage for ${testname}"
+  cd $testdir
+  lcov --zerocounters  --directory .
+  cd ${basepath}/${builddir}
+  ctest -R $testname
+  cd $testdir
+  lcov --directory . --capture --output-file ${testname}.info.tmp
+  lcov --extract ${testname}.info.tmp "*${basepath}/include/**/*" --output-file ${testname}.info
+  rm ${testname}.info.tmp
+  cd ${basepath}/${builddir}
+  lcov --add-tracefile ${testdir}/${testname}.info --output-file all_tests.info
+done
+
+cd ${basepath}
+genhtml --output-directory ./coverage \
+  --demangle-cpp --num-spaces 2 --sort \
+  --title "PFASST++ Test Coverage" --prefix ${basepath}/include \
+  --function-coverage --branch-coverage --legend ${basepath}/${builddir}/all_tests.info

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ foreach(test ${TESTS})
     set_target_properties(${test}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
     )
+    if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+        set_target_properties(${test}
+            PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage -fprofile-arcs"
+                       LINK_FLAGS "-fprofile-arcs"
+        )
+    endif()
     add_test(NAME ${test}
         COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/${test} --gtest_output=xml:${test}_out.xml
     )

--- a/tests/examples/advection_diffusion/CMakeLists.txt
+++ b/tests/examples/advection_diffusion/CMakeLists.txt
@@ -30,6 +30,12 @@ foreach(test ${TESTS})
     set_target_properties(${test}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/examples/advection_diffusion
     )
+    if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+        set_target_properties(${test}
+            PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage -fprofile-arcs"
+                       LINK_FLAGS "-fprofile-arcs"
+        )
+    endif()
     add_test(NAME ${test}
         COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/examples/advection_diffusion/${test} --gtest_output=xml:${test}_out.xml
     )
@@ -44,8 +50,15 @@ if(${pfasst_WITH_MPI})
         if(NOT FFTW_FOUND)
           add_dependencies(${test} googlemock fftw3)
         endif()
-	if(MPI_COMPILE_FLAGS)
-            set_target_properties(${test} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
+        if(MPI_COMPILE_FLAGS)
+            if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+                set_target_properties(${test}
+                    PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS} -ftest-coverage -fprofile-arcs"
+                               LINK_FLAGS "-fprofile-arcs"
+                )
+            else()
+                set_target_properties(${test} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
+            endif()
         endif()
         if(MPI_LINK_FLAGS)
             set_target_properties(${test} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")

--- a/tests/examples/scalar/CMakeLists.txt
+++ b/tests/examples/scalar/CMakeLists.txt
@@ -20,6 +20,12 @@ foreach(test ${TESTS})
     set_target_properties(${test}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/examples/scalar
     )
+    if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+        set_target_properties(${test}
+            PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage -fprofile-arcs"
+                       LINK_FLAGS "-fprofile-arcs"
+        )
+    endif()
     add_test(NAME ${test}
         COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/examples/scalar/${test} --gtest_output=xml:${test}_out.xml
     )


### PR DESCRIPTION
I need a lot more CMake magic to get MPI-aware profilers such as Scalasca or Tau working. I'll dig into that next week.
Meanwhile, look at those awesome Test Coverage Reports (I'll train Jenkins to produce and serve those). :smile: You'll need `lcov` for those.
