### PR TITLE
Remove useless toplevel "pfasst.hpp".

### DIFF
--- a/examples/advection_diffusion/mpi_pfasst.cpp
+++ b/examples/advection_diffusion/mpi_pfasst.cpp
@@ -10,7 +10,6 @@
 #include <mpi.h>
 #include <fftw3.h>
 
-#include <pfasst.hpp>
 #include <pfasst/pfasst.hpp>
 #include <pfasst/mpi_communicator.hpp>
 #include <pfasst/encap/automagic.hpp>

--- a/examples/advection_diffusion/serial_mlsdc.cpp
+++ b/examples/advection_diffusion/serial_mlsdc.cpp
@@ -8,7 +8,6 @@
 
 #include <fftw3.h>
 
-#include <pfasst.hpp>
 #include <pfasst/mlsdc.hpp>
 #include <pfasst/encap/vector.hpp>
 

--- a/examples/advection_diffusion/serial_mlsdc_autobuild.cpp
+++ b/examples/advection_diffusion/serial_mlsdc_autobuild.cpp
@@ -15,7 +15,6 @@
 
 #include <fftw3.h>
 
-#include <pfasst.hpp>
 #include <pfasst/mlsdc.hpp>
 #include <pfasst/encap/automagic.hpp>
 #include <pfasst/encap/vector.hpp>

--- a/examples/advection_diffusion/vanilla_sdc.cpp
+++ b/examples/advection_diffusion/vanilla_sdc.cpp
@@ -9,7 +9,6 @@
 
 #include <fftw3.h>
 
-#include <pfasst.hpp>
 #include <pfasst/sdc.hpp>
 #include <pfasst/encap/vector.hpp>
 

--- a/examples/scalar/scalar_sdc.cpp
+++ b/examples/scalar/scalar_sdc.cpp
@@ -12,7 +12,6 @@
 
 #include<complex>
 
-#include<pfasst.hpp>
 #include<pfasst/sdc.hpp>
 #include<pfasst/encap/vector.hpp>
 

--- a/examples/vanderpol/vdp_sdc.cpp
+++ b/examples/vanderpol/vdp_sdc.cpp
@@ -3,7 +3,6 @@
  *
  */
 
-#include<pfasst.hpp>
 #include<pfasst/sdc.hpp>
 #include<pfasst/encap/vector.hpp>
 

--- a/include/pfasst.hpp
+++ b/include/pfasst.hpp
@@ -1,6 +1,0 @@
-#ifndef _PFASST_HPP_
-#define _PFASST_HPP_
-
-#include "pfasst/interfaces.hpp"
-
-#endif


### PR DESCRIPTION
Signed-off-by: Matthew Emmett memmett@gmail.com
