### PR TITLE
cmake: some cleanup of linking parameters

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -5,15 +5,6 @@ set(3rdparty_DEPENDEND_LIBS ${3rdparty_DEPENDEND_LIBS})
 message(STATUS "--------------------------------------------------------------------------------")
 message(STATUS "Boost")
 
-# if(pfasst_BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
-#     set(Boost_USE_STATIC_LIBS OFF)
-#     set(pfasst_BUILD_SHARED_LIBS ON)
-#     set(BUILD_SHARED_LIBS ON)
-# else()
-#     set(Boost_USE_STATIC_LIBS ON)
-#     set(pfasst_BUILD_SHARED_LIBS OFF)
-#     set(BUILD_SHARED_LIBS OFF)
-# endif()
 set(Boost_USE_MULTITHREADED ON)
 
 if(${compiler_version_available} AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
@@ -112,6 +103,9 @@ if(pfasst_BUILD_EXAMPLES)
 endif()
 
 if(pfasst_BUILD_TESTS)
+    set(TESTS_3rdparty_INCLUDES ${TESTS_3rdparty_INCLUDES})
+    set(TESTS_3rdparty_DEPENDEND_LIBS ${TESTS_3rdparty_DEPENDEND_LIBS})
+
     message(STATUS "--------------------------------------------------------------------------------")
     set(GMOCK_SOURCE_URL "http://googlemock.googlecode.com/files/gmock-1.7.0.zip")
     message(STATUS "Google Testing Framework (gtest & gmock)")
@@ -127,12 +121,12 @@ if(pfasst_BUILD_TESTS)
       UPDATE_COMMAND ""
       PATCH_COMMAND ""
       CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-      -DCMAKE_C_COMPILE=${CMAKE_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-      -DGTEST_USE_OWN_TR1_TUPLE=ON
-      -Dgtest_force_shared_crt=ON
-      -Dgmock_build_tests=${gtest_BUILD_TESTS}
+        -DCMAKE_C_COMPILE=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        -DGTEST_USE_OWN_TR1_TUPLE=ON
+        -Dgtest_force_shared_crt=ON
+        -Dgmock_build_tests=OFF
       # Disable install step
       INSTALL_COMMAND ""
       # Wrap download, configure and build steps in a script to log output
@@ -143,16 +137,18 @@ if(pfasst_BUILD_TESTS)
 
     # Specify include dir
     ExternalProject_Get_Property(googlemock source_dir)
-    list(APPEND 3rdparty_INCLUDES ${source_dir}/include ${source_dir}/gtest/include)
+    list(APPEND TESTS_3rdparty_INCLUDES ${source_dir}/include ${source_dir}/gtest/include)
 
     ExternalProject_Get_Property(googlemock binary_dir)
     set(Suffix ".a")
     set(Pthread "-pthread")
 
-    list(APPEND 3rdparty_DEPENDEND_LIBS ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gmock${Suffix})
-    list(APPEND 3rdparty_DEPENDEND_LIBS ${Pthread})
+    list(APPEND TESTS_3rdparty_DEPENDEND_LIBS ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gmock${Suffix})
+    list(APPEND TESTS_3rdparty_DEPENDEND_LIBS ${Pthread})
 endif()
 
 # propagate include lists to parent directory
 set(3rdparty_DEPENDEND_LIBS ${3rdparty_DEPENDEND_LIBS} PARENT_SCOPE)
 set(3rdparty_INCLUDES ${3rdparty_INCLUDES} PARENT_SCOPE)
+set(TESTS_3rdparty_DEPENDEND_LIBS ${TESTS_3rdparty_DEPENDEND_LIBS} PARENT_SCOPE)
+set(TESTS_3rdparty_INCLUDES ${TESTS_3rdparty_INCLUDES} PARENT_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ set(pfasst_DEPENDEND_LIBS)
 
 if(pfasst_BUILD_TESTS)
     enable_testing()
+    set(TESTS_3rdparty_INCLUDES)
+    set(TESTS_3rdparty_DEPENDEND_LIBS)
 endif(pfasst_BUILD_TESTS)
 
 # Add / include 3rd-party libraries

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Building and Running Tests
 include_directories(
     ${3rdparty_INCLUDES}
+    ${TESTS_3rdparty_INCLUDES}
     ${pfasst_INCLUDES}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
@@ -16,6 +17,7 @@ foreach(test ${TESTS})
     add_dependencies(${test} googlemock)
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
+        ${TESTS_3rdparty_DEPENDEND_LIBS}
         ${pfasst_DEPENDED_LIBS}
     )
     if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)

--- a/tests/examples/advection_diffusion/CMakeLists.txt
+++ b/tests/examples/advection_diffusion/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Building and Running Tests
 include_directories(
     ${3rdparty_INCLUDES}
+    ${TESTS_3rdparty_INCLUDES}
     ${FFTW_INCLUDE_PATH}
     ${pfasst_INCLUDES}
 )
@@ -24,6 +25,7 @@ foreach(test ${TESTS})
     endif()
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
+        ${TESTS_3rdparty_DEPENDEND_LIBS}
         ${FFTW_LIBRARIES}
         ${pfasst_DEPENDED_LIBS}
     )
@@ -62,6 +64,7 @@ if(${pfasst_WITH_MPI})
         endif()
         target_link_libraries(${test}
             ${3rdparty_DEPENDEND_LIBS}
+            ${TESTS_3rdparty_DEPENDEND_LIBS}
             ${FFTW_LIBRARIES}
             ${pfasst_DEPENDED_LIBS}
             ${MPI_CXX_LIBRARIES}

--- a/tests/examples/scalar/CMakeLists.txt
+++ b/tests/examples/scalar/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Building and Running Tests
 include_directories(
     ${3rdparty_INCLUDES}
+    ${TESTS_3rdparty_INCLUDES}
     ${pfasst_INCLUDES}
 )
 
@@ -15,6 +16,7 @@ foreach(test ${TESTS})
     add_dependencies(${test} googlemock)
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
+        ${TESTS_3rdparty_DEPENDEND_LIBS}
         ${pfasst_DEPENDED_LIBS}
     )
     if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)

--- a/tests/examples/vanderpol/CMakeLists.txt
+++ b/tests/examples/vanderpol/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Building and Running Tests
 include_directories(
     ${3rdparty_INCLUDES}
+    ${TESTS_3rdparty_INCLUDES}
     ${pfasst_INCLUDES}
 )
 
@@ -14,6 +15,7 @@ foreach(test ${TESTS})
     add_dependencies(${test} googlemock)
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
+        ${TESTS_3rdparty_DEPENDEND_LIBS}
         ${pfasst_DEPENDED_LIBS}
     )
     if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)


### PR DESCRIPTION
when building the tests, we don't need to link to gtest in the examples
