### PR TITLE
cmake: set minimum Boost version 1.53.0

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -18,7 +18,7 @@ if(${CMAKE_VERBOSE_MAKEFILE})
     set(Boost_DETAILED_FAILURE_MSG ON)
 endif()
 
-find_package(Boost COMPONENTS program_options REQUIRED)
+find_package(Boost 1.53.0 COMPONENTS program_options REQUIRED)
 message(STATUS "Boost include path: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost library path: ${Boost_LIBRARY_DIRS}")
 list(APPEND 3rdparty_INCLUDES ${Boost_INCLUDE_DIRS})

--- a/doc/source/installing.md
+++ b/doc/source/installing.md
@@ -4,6 +4,8 @@
 
 * A recent C++ compiler that supports (most of) the C++11 standard.
 * The [CMake](http://cmake.org/) build tool.
+* The [Boost](https://boost.org/) libraries at least of version 1.53.0.
+  Especially `boost::program_options` is required.
 
 
 ## Obtaining the Sources


### PR DESCRIPTION
boost::multiprecision was introduced in 1.53.0, which has been tested
successfully with PFASST++

this fixes #104
