### PR TITLE
logging: now with awesome color and fine-tunable verbosity levels

### DIFF
--- a/include/pfasst.hpp
+++ b/include/pfasst.hpp
@@ -14,42 +14,9 @@ namespace pfasst
     SDC<>::enable_config_options(0);
     Quadrature::enable_config_options(0);
     config::init_config();
-    config::read_commandline(argc, argv);
     log::start_log(argc, argv);
+    config::read_commandline(argc, argv);
   }
 } // ::pfasst
-
-#include <string>
-using namespace std;
-
-struct OUT
-{
-  public:
-    static const string black;
-    static const string red;
-    static const string green;
-    static const string yellow;
-    static const string blue;
-    static const string magenta;
-    static const string cyan;
-    static const string white;
-
-    static const string bold;
-    static const string underline;
-
-    static const string reset;
-};
-
-const string OUT::black = "\033[30m";
-const string OUT::red = "\033[31m";
-const string OUT::green = "\033[32m";
-const string OUT::yellow = "\033[33m";
-const string OUT::blue = "\033[34m";
-const string OUT::magenta = "\033[35m";
-const string OUT::cyan = "\033[36m";
-const string OUT::white = "\033[37m";
-const string OUT::bold = "\033[1m";
-const string OUT::underline = "\033[4m";
-const string OUT::reset = "\033[0m";
 
 #endif

--- a/include/pfasst/config.hpp
+++ b/include/pfasst/config.hpp
@@ -125,7 +125,14 @@ namespace pfasst
     static string pretty_print()
     {
       stringstream s;
-      s << Options::get_instance().get_all_options();
+      s << "Logging Options:" << endl
+        << "  -v [ --verbose ]       activates maximum verbosity" << endl
+        << "  --v=arg                activates verbosity upto verbose level 2" << endl
+        << "                         (valid range: 0-9)" << endl
+        << "  -vmodule=arg           actives verbose logging for specific module" << endl
+        << "                         (see [1] for details)" << endl;
+      s << Options::get_instance().get_all_options() << endl;
+      s << "[1]: https://github.com/easylogging/easyloggingpp#vmodule";
       return s.str();
     }
 


### PR DESCRIPTION
see `pfasst::log::test_logging_levels()` for usage examples

You'll get most of it in terminals with color support. :sunglasses: 
