### PR TITLE
adding .mailmap file to fix up commit authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Torbjörn Klatt <t.klatt@fz-juelich.de> <torbjoernk@users.noreply.github.com>
+Matthew Emmett <memmett@gmail.com> <matthew@emmett.ca>
+Matthew Emmett <memmett@gmail.com> <mwemmett@lbl.gov>
+Daniel Ruprecht <daniel.ruprecht@usi.ch> danielru <daniel@comp.usilu.net>
+Daniel Ruprecht <daniel.ruprecht@usi.ch> Daniel <daniel@D-Laptop.local>
+Daniel Ruprecht <daniel.ruprecht@usi.ch> Daniel <daniel@comp.usilu.net>


### PR DESCRIPTION
just a minor fix for the git-cli-folks (GitHub can deal with this without this file)
