### PR TITLE
docu: don't generate documentation for Easylogging++

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -698,7 +698,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = include/pfasst/easylogging++.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
This should also workaround a buffer-overflow in Jenkins.
