### PR TITLE
improve logging by introducing named loggers

### DIFF
--- a/examples/advection_diffusion/advection_diffusion_sweeper.hpp
+++ b/examples/advection_diffusion/advection_diffusion_sweeper.hpp
@@ -99,7 +99,7 @@ namespace pfasst
 
           virtual ~AdvectionDiffusionSweeper()
           {
-            LOG(INFO) << "number of f1 evals: " << this->nf1evals;
+            CLOG(INFO, "Advec") << "number of f1 evals: " << this->nf1evals;
           }
           //! @}
 
@@ -141,7 +141,7 @@ namespace pfasst
 
             auto n = this->get_controller()->get_step();
             auto k = this->get_controller()->get_iteration();
-            LOG(INFO) << "err: " << n << " " << k << " " << max << " (" << qend.size() << "," << predict << ")";
+            CLOG(INFO, "Advec") << "err: " << n << " " << k << " " << max << " (" << qend.size() << "," << predict << ")";
 
             this->errors.insert(vtype(ktype(n, k), max));
           }
@@ -163,7 +163,7 @@ namespace pfasst
 
             auto n = this->get_controller()->get_step();
             auto k = this->get_controller()->get_iteration();
-            LOG(INFO) << "res: " << n << " " << k << " " << rmax << " (" << residuals.size() << ")";
+            CLOG(INFO, "Advec") << "res: " << n << " " << k << " " << rmax << " (" << residuals.size() << ")";
 
             this->residuals[ktype(n, k)] = rmax;
           }

--- a/examples/advection_diffusion/serial_mlsdc.cpp
+++ b/examples/advection_diffusion/serial_mlsdc.cpp
@@ -28,14 +28,14 @@ namespace pfasst
       {
         MLSDC<> mlsdc;
 
-        const size_t nsteps = 4;
-        const double dt     = 0.01;
-        const size_t niters = 8;
+        const size_t nsteps = config::get_value<size_t>("num_steps", 4);
+        const double dt     = config::get_value<double>("delta_step", 0.01);
+        const size_t niters = config::get_value<size_t>("num_iter", 8);
         const int    xrat   = 2;
         const int    trat   = 2;
 
-        size_t nnodes = 5;
-        size_t ndofs  = 128;
+        size_t nnodes = config::get_value<size_t>("num_nodes", 5);
+        size_t ndofs  = config::get_value<size_t>("spatial_dofs", 128);
 
         /*
          * build space/time discretisation levels and add them to mlsdc
@@ -93,8 +93,12 @@ namespace pfasst
 }  // ::pfasst
 
 #ifndef PFASST_UNIT_TESTING
-int main(int /*argc*/, char** /*argv*/)
+int main(int argc, char** argv)
 {
+  pfasst::examples::advection_diffusion::AdvectionDiffusionSweeper<>::enable_config_options();
+  pfasst::init(argc, argv);
+  pfasst::log::add_custom_logger("Advec");
+
   pfasst::examples::advection_diffusion::run_serial_mlsdc(3);
 }
 #endif

--- a/examples/advection_diffusion/serial_mlsdc.cpp
+++ b/examples/advection_diffusion/serial_mlsdc.cpp
@@ -10,6 +10,8 @@ using namespace std;
 #include <fftw3.h>
 
 #include <pfasst.hpp>
+#include <pfasst/logging.hpp>
+#include <pfasst/config.hpp>
 #include <pfasst/mlsdc.hpp>
 #include <pfasst/encap/vector.hpp>
 using namespace pfasst::encap;

--- a/examples/advection_diffusion/serial_mlsdc_autobuild.cpp
+++ b/examples/advection_diffusion/serial_mlsdc_autobuild.cpp
@@ -17,6 +17,8 @@ using namespace std;
 #include <fftw3.h>
 
 #include <pfasst.hpp>
+#include <pfasst/logging.hpp>
+#include <pfasst/config.hpp>
 #include <pfasst/mlsdc.hpp>
 #include <pfasst/encap/automagic.hpp>
 #include <pfasst/encap/vector.hpp>
@@ -29,49 +31,76 @@ using pfasst::examples::advection_diffusion::AdvectionDiffusionSweeper;
 using pfasst::examples::advection_diffusion::SpectralTransfer1D;
 
 
-int main(int /*argc*/, char** /*argv*/)
+namespace pfasst
 {
-  MLSDC<> mlsdc;
+  namespace examples
+  {
+    namespace advection_diffusion
+    {
+      tuple<error_map, residual_map> run_serial_mlsdc_autobuild()
+      {
+        MLSDC<> mlsdc;
 
-  const size_t nsteps = 4;
-  const double dt     = 0.01;
-  const size_t niters = 4;
+        const size_t nsteps = config::get_value<size_t>("num_steps", 4);
+        const double dt     = config::get_value<double>("delta_step", 0.01);
+        const size_t niters = config::get_value<size_t>("num_iter", 4);
 
-  vector<pair<size_t, pfasst::quadrature::QuadratureType>> nodes = {
-    { 3, pfasst::quadrature::QuadratureType::GaussLobatto },
-    { 5, pfasst::quadrature::QuadratureType::GaussLobatto }
-  };
+        vector<pair<size_t, pfasst::quadrature::QuadratureType>> nodes = {
+          { 3, pfasst::quadrature::QuadratureType::GaussLobatto },
+          { 5, pfasst::quadrature::QuadratureType::GaussLobatto }
+        };
 
-  vector<size_t> ndofs = { 64, 128 };
+        vector<size_t> ndofs = { 64, 128 };
 
-  /*
-   * the 'build' function is called once for each level, and returns a
-   * tuple containing a sweeper, encapsulation factory, and transfer
-   * routines.  in this case our builder is a lambda function that
-   * captures the 'ndofs' variable from above.
-   */
-  auto build_level = [ndofs](size_t level) {
-    auto factory  = make_shared<VectorFactory<double>>(ndofs[level]);
-    auto sweeper  = make_shared<AdvectionDiffusionSweeper<>>(ndofs[level]);
-    auto transfer = make_shared<SpectralTransfer1D<>>();
+        /*
+         * the 'build' function is called once for each level, and returns a
+         * tuple containing a sweeper, encapsulation factory, and transfer
+         * routines.  in this case our builder is a lambda function that
+         * captures the 'ndofs' variable from above.
+         */
+        auto build_level = [ndofs](size_t level) {
+          auto factory  = make_shared<VectorFactory<double>>(ndofs[level]);
+          auto sweeper  = make_shared<AdvectionDiffusionSweeper<>>(ndofs[level]);
+          auto transfer = make_shared<SpectralTransfer1D<>>();
 
-    return AutoBuildTuple<>(sweeper, transfer, factory);
-  };
+          return AutoBuildTuple<>(sweeper, transfer, factory);
+        };
 
-  /*
-   * the 'initial' function is called once for each level to set the
-   * intial conditions.
-   */
-  auto initial = [](shared_ptr<EncapSweeper<>> sweeper, shared_ptr<Encapsulation<>> q0) {
-    auto ad = dynamic_pointer_cast<AdvectionDiffusionSweeper<>>(sweeper);
-    assert(ad);
-    ad->exact(q0, 0.0);
-  };
+        /*
+         * the 'initial' function is called once for each level to set the
+         * intial conditions.
+         */
+        auto initial = [](shared_ptr<EncapSweeper<>> sweeper, shared_ptr<Encapsulation<>> q0) {
+          auto ad = dynamic_pointer_cast<AdvectionDiffusionSweeper<>>(sweeper);
+          assert(ad);
+          ad->exact(q0, 0.0);
+        };
 
-  auto_build(mlsdc, nodes, build_level);
-  auto_setup(mlsdc, initial);
-  mlsdc.set_duration(0.0, nsteps*dt, dt, niters);
-  mlsdc.run();
+        auto_build(mlsdc, nodes, build_level);
+        auto_setup(mlsdc, initial);
+        mlsdc.set_duration(0.0, nsteps*dt, dt, niters);
+        mlsdc.run();
 
-  fftw_cleanup();
+        fftw_cleanup();
+
+        tuple<error_map, residual_map> rinfo;
+        get<0>(rinfo) = mlsdc.get_finest<AdvectionDiffusionSweeper<>>()->get_errors();
+        for (auto l = mlsdc.coarsest(); l <= mlsdc.finest(); ++l) {
+          get<1>(rinfo).insert(pair<size_t, error_map>(l.level, l.current<AdvectionDiffusionSweeper<>>()->get_residuals()));
+        }
+        return rinfo;
+      }
+    }  // ::pfasst::examples::advection_diffusion
+  }  // ::pfasst::examples
+}  // ::pfasst
+
+#ifndef PFASST_UNIT_TESTING
+int main(int argc, char** argv)
+{
+  pfasst::examples::advection_diffusion::AdvectionDiffusionSweeper<>::enable_config_options();
+  pfasst::init(argc, argv);
+  pfasst::log::add_custom_logger("Advec");
+
+  pfasst::examples::advection_diffusion::run_serial_mlsdc_autobuild();
 }
+#endif

--- a/examples/advection_diffusion/vanilla_sdc.cpp
+++ b/examples/advection_diffusion/vanilla_sdc.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
 {
   pfasst::examples::advection_diffusion::AdvectionDiffusionSweeper<>::enable_config_options();
   pfasst::init(argc, argv);
+  pfasst::log::add_custom_logger("Advec");
 
   pfasst::examples::advection_diffusion::run_vanilla_sdc(0.0);
 }

--- a/include/pfasst/encap/imex_sweeper.hpp
+++ b/include/pfasst/encap/imex_sweeper.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "../globals.hpp"
+#include "../logging.hpp"
 #include "../quadrature.hpp"
 #include "encapsulation.hpp"
 #include "encap_sweeper.hpp"
@@ -292,6 +293,8 @@ namespace pfasst
         {
           time dt = this->get_controller()->get_time_step();
           time t  = this->get_controller()->get_time();
+          CLOG(INFO, "Sweeper") << "predicting step " << this->get_controller()->get_step() + 1
+                                << " (t=" << t << ", dt=" << dt << ")";
 
           if (initial) {
             this->state[0]->copy(this->start_state);
@@ -319,6 +322,8 @@ namespace pfasst
           UNUSED(initial);
           time dt = this->get_controller()->get_time_step();
           time t  = this->get_controller()->get_time();
+          CLOG(INFO, "Sweeper") << "predicting step " << this->get_controller()->get_step() + 1
+                                << " (t=" << t << ", dt=" << dt << ")";
           time ds;
 
           shared_ptr<Encapsulation<time>> rhs = this->get_factory()->create(pfasst::encap::solution);
@@ -349,6 +354,8 @@ namespace pfasst
           auto const nodes = this->quadrature->get_nodes();
           auto const dt    = this->get_controller()->get_time_step();
           auto const s_mat = this->quadrature->get_s_mat().block(1, 0, nodes.size()-1, nodes.size());
+          CLOG(INFO, "Sweeper") << "sweeping on step " << this->get_controller()->get_step() + 1
+                                << " in iteration " << this->get_controller()->get_iteration() << " (dt=" << dt << ")";
           time ds;
 
           this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_expl, true);
@@ -384,6 +391,8 @@ namespace pfasst
           auto const nodes = this->quadrature->get_nodes();
           auto const dt    = this->get_controller()->get_time_step();
           auto const s_mat = this->quadrature->get_s_mat();
+          CLOG(INFO, "Sweeper") << "sweeping on step " << this->get_controller()->get_step() + 1
+                                << " in iteration " << this->get_controller()->get_iteration() << " (dt=" << dt << ")";
           time ds;
 
           this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_expl, true);

--- a/include/pfasst/mlsdc.hpp
+++ b/include/pfasst/mlsdc.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "controller.hpp"
+#include "logging.hpp"
 
 using namespace std;
 
@@ -35,6 +36,7 @@ namespace pfasst
       void perform_sweeps(size_t level)
       {
         auto sweeper = this->get_level(level);
+        CLOG(INFO, "Controller") << "on level " << level + 1 << "/" << this->nlevels();
         for (size_t s = 0; s < this->nsweeps[level]; s++) {
           if (predict) {
             sweeper->predict(initial & predict);
@@ -97,6 +99,7 @@ namespace pfasst
           return l;
         }
 
+        CVLOG(1, "Controller") << "Cycle down onto level " << l.level << "/" << this->nlevels();
         trns->restrict(crse, fine, initial);
         trns->fas(this->get_time_step(), crse, fine);
         crse->save();
@@ -117,6 +120,7 @@ namespace pfasst
         auto crse = l.coarse();
         auto trns = l.transfer();
 
+        CVLOG(1, "Controller") << "Cycle up onto level " << l.level + 1 << "/" << this->nlevels();
         trns->interpolate(fine, crse);
 
         if (l < this->finest()) {

--- a/tests/examples/advection_diffusion/test_advection_diffusion.cpp
+++ b/tests/examples/advection_diffusion/test_advection_diffusion.cpp
@@ -130,5 +130,7 @@ TEST(FASTest, SerialMLSDC)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  pfasst::log::start_log(argc, argv);
+  pfasst::log::add_custom_logger("Advec");
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
By introducing named loggers, we are able to denote specific loggers to certain parts of the code to ease grepping for interesting parts of the log.

Currently, there are loggers (beside "default") for "Controller" (e.g. SDC, MLSDC), "Sweeper" (e.g. IMEX), "Quadrature" (yet unused) and user defined ones such as "Advec" (for the AdvectionDiffusionSweeper).