### PR TITLE
cmake: specify minimum patch version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.6)
 project(pfasst)
 
 list(APPEND CMAKE_MODULE_PATH ${pfasst_SOURCE_DIR}/cmake)


### PR DESCRIPTION
I've tested a few CMake versions of the 2.8 series and discovered, that we could only support from 2.8.6 (release October 4th, 2011) onwards.