### PR TITLE
Splitting up declerations and definitions into separate files

### DIFF
--- a/examples/boris/boris_sweeper.hpp
+++ b/examples/boris/boris_sweeper.hpp
@@ -178,7 +178,7 @@ namespace pfasst
           virtual void set_state(shared_ptr<const encap_type> u0, size_t m);
           virtual void set_start_state(shared_ptr<const encap_type> u0);
           virtual shared_ptr<Encapsulation<time>> get_state(size_t m) const override;
-          virtual shared_ptr<encap_type> get_start_state() const;
+          virtual shared_ptr<Encapsulation<time>> get_start_state() const;
           virtual shared_ptr<acceleration_type> get_tau_q_as_force(size_t m) const;
           virtual shared_ptr<acceleration_type> get_tau_qq_as_force(size_t m) const;
           virtual shared_ptr<Encapsulation<time>> get_saved_state(size_t m) const override;

--- a/examples/boris/boris_sweeper_impl.hpp
+++ b/examples/boris/boris_sweeper_impl.hpp
@@ -269,7 +269,7 @@ namespace pfasst
       }
 
       template<typename scalar, typename time>
-      shared_ptr<typename BorisSweeper<scalar, time>::encap_type> BorisSweeper<scalar, time>::get_start_state() const
+      shared_ptr<Encapsulation<time>> BorisSweeper<scalar, time>::get_start_state() const
       {
         return this->start_particles;
       }

--- a/examples/boris/injective_transfer.hpp
+++ b/examples/boris/injective_transfer.hpp
@@ -132,7 +132,7 @@ namespace pfasst
             auto fine = dynamic_pointer_cast<const BorisSweeper<scalar, time>>(src);
             assert(fine);
             CVLOG(5, "BorisTransfer") << "fine:       " << fine->get_start_state();
-            coarse->set_start_state(fine->get_start_state());
+            coarse->set_start_state(dynamic_pointer_cast<typename BorisSweeper<scalar, time>::encap_type>(fine->get_start_state()));
             CVLOG(5, "BorisTransfer") << "restricted: " << coarse->get_start_state();
           }
 

--- a/include/pfasst/config.hpp
+++ b/include/pfasst/config.hpp
@@ -1,13 +1,7 @@
 #ifndef _PFASST__CONFIG_HPP_
 #define _PFASST__CONFIG_HPP_
 
-#include <algorithm>
-#include <cassert>
-#include <exception>
 #include <fstream>
-#include <functional>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <map>
 using namespace std;
@@ -15,9 +9,9 @@ using namespace std;
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
+
 namespace pfasst
 {
-
   namespace config
   {
     /**
@@ -36,103 +30,35 @@ namespace pfasst
         vector<string> unrecognized_args;
         bool initialized = false;
 
-        options() {}
+        options();
         options(const options&) = delete;
         void operator=(const options&) = delete;
 
       public:
-        static options& get_instance()
-        {
-          static options instance;
-          return instance;
-        }
-
-        po::variables_map& get_variables_map()
-        {
-          return this->variables_map;
-        }
-
-        po::options_description& get_all_options()
-        {
-          return this->all_options;
-        }
-
-        vector<string>& get_unrecognized_args()
-        {
-          return this->unrecognized_args;
-        }
-
-        static void add_option(string group, string option, string help)
-        {
-          auto& opts = get_instance();
-          opts.option_groups.emplace(make_pair<string,
-                                     po::options_description>(string(group),
-                                                              po::options_description(string(group), LINE_WIDTH)));
-          opts.option_groups[group].add_options()
-            (option.c_str(), help.c_str());
-        }
+        static options& get_instance();
+        po::variables_map& get_variables_map();
+        po::options_description& get_all_options();
+        vector<string>& get_unrecognized_args();
+        static void add_option(const string& group, const string& option, const string& help);
 
         template<typename T>
-        static void add_option(string group, string option, string help)
-        {
-          auto& opts = get_instance();
+        static void add_option(const string& group, const string& option, const string& help);
 
-          opts.option_groups.emplace(make_pair<string,
-                                     po::options_description>(string(group),
-                                                              po::options_description(string(group), LINE_WIDTH)));
-          opts.option_groups[group].add_options()
-            (option.c_str(), po::value<T>(), help.c_str());
-        }
-
-        void init()
-        {
-          if (!this->initialized) {
-            for (auto const & kv : this->option_groups) {
-              this->all_options.add(kv.second);
-            }
-          }
-          this->initialized = true;
-        }
-
+        void init();
     };
 
     template<typename T>
-    inline static T get_value(const string& name, const T& default_val)
-    {
-      return options::get_instance().get_variables_map().count(name)
-              ? options::get_instance().get_variables_map()[name].as<T>() : default_val;
-    }
+    static T get_value(const string& name, const T& default_val);
 
     template<typename T>
-    inline static T get_value(const string& name)
-    {
-      return options::get_instance().get_variables_map()[name].as<T>();
-    }
+    static T get_value(const string& name);
 
     /**
      * @returns empty string if params are set and `if_no_params` is `true`
      */
-    inline static string print_help(bool if_no_params = false)
-    {
-      bool no_params_given = options::get_instance().get_variables_map().empty();
+    static string print_help(bool if_no_params = false);
 
-      if (!if_no_params || (if_no_params && no_params_given)) {
-        stringstream s;
-        s << options::get_instance().get_all_options() << endl;
-        s << "Logging options:" << endl
-          << "  -v [ --verbose ]       activates maximum verbosity" << endl
-          << "  --v=arg                activates verbosity upto verbose level 2" << endl
-          << "                         (valid range: 0-9)" << endl
-          << "  -vmodule=arg           actives verbose logging for specific module" << endl
-          << "                         (see [1] for details)" << endl;
-        s << "[1]: https://github.com/easylogging/easyloggingpp#vmodule" << endl;
-        return s.str();
-      } else {
-        return string();
-      }
-    }
-
-    inline static void read_commandline(int argc, char* argv[], bool exit_on_help = true)
+    static inline void read_commandline(int argc, char* argv[], bool exit_on_help = true)
     {
       po::parsed_options parsed = po::command_line_parser(argc, argv)
                                     .options(options::get_instance().get_all_options())
@@ -151,7 +77,7 @@ namespace pfasst
     /**
      * @throws invalid_argument if the given file could not be opened
      */
-    inline static void read_config_file(string file_name)
+    static inline void read_config_file(const string& file_name)
     {
       ifstream ifs(file_name.c_str(), ios_base::in);
       if (!ifs) {
@@ -163,7 +89,7 @@ namespace pfasst
       }
     }
 
-    inline static void init()
+    static inline void init()
     {
       options::add_option("Global", "help,h", "display this help message");
 
@@ -176,9 +102,9 @@ namespace pfasst
 
       options::get_instance().init();
     }
-
   }  // ::pfasst::config
-
 }  // ::pfasst
+
+#include "config_impl.hpp"
 
 #endif  // _PFASST__CONFIG_HPP_

--- a/include/pfasst/config_impl.hpp
+++ b/include/pfasst/config_impl.hpp
@@ -1,0 +1,105 @@
+#include "config.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <utility>
+using namespace std;
+
+
+namespace pfasst
+{
+  namespace config
+  {
+    options::options()
+    {}
+
+    options& options::get_instance()
+    {
+      static options instance;
+      return instance;
+    }
+
+    po::variables_map& options::get_variables_map()
+    {
+      return this->variables_map;
+    }
+
+    po::options_description& options::get_all_options()
+    {
+      return this->all_options;
+    }
+
+    vector<string>& options::get_unrecognized_args()
+    {
+      return this->unrecognized_args;
+    }
+
+    void options::add_option(const string& group, const string& option, const string& help)
+    {
+      auto& opts = get_instance();
+      opts.option_groups.emplace(make_pair<string,
+                                 po::options_description>(string(group),
+                                                          po::options_description(string(group),
+                                                                                  LINE_WIDTH)));
+      opts.option_groups[group].add_options()
+                                  (option.c_str(), help.c_str());
+    }
+
+    template<typename T>
+    void options::add_option(const string& group, const string& option, const string& help)
+    {
+      auto& opts = get_instance();
+
+      opts.option_groups.emplace(make_pair<string,
+                                 po::options_description>(string(group),
+                                                          po::options_description(string(group),
+                                                                                  LINE_WIDTH)));
+      opts.option_groups[group].add_options()
+                                  (option.c_str(), po::value<T>(), help.c_str());
+    }
+
+    void options::init()
+    {
+      if (!this->initialized) {
+        for (auto const & kv : this->option_groups) {
+          this->all_options.add(kv.second);
+        }
+      }
+      this->initialized = true;
+    }
+
+
+    template<typename T>
+    static T get_value(const string& name, const T& default_val)
+    {
+      return options::get_instance().get_variables_map().count(name)
+              ? options::get_instance().get_variables_map()[name].as<T>() : default_val;
+    }
+
+    template<typename T>
+    static T get_value(const string& name)
+    {
+      return options::get_instance().get_variables_map()[name].as<T>();
+    }
+
+    static string print_help(bool if_no_params)
+    {
+      bool no_params_given = options::get_instance().get_variables_map().empty();
+
+      if (!if_no_params || (if_no_params && no_params_given)) {
+        stringstream s;
+        s << options::get_instance().get_all_options() << endl;
+        s << "Logging options:" << endl
+          << "  -v [ --verbose ]       activates maximum verbosity" << endl
+          << "  --v=arg                activates verbosity upto verbose level `arg`" << endl
+          << "                         (valid range: 0-9)" << endl
+          << "  -vmodule=arg           actives verbose logging for specific module" << endl
+          << "                         (see [1] for details)" << endl << endl
+          << "[1]: https://github.com/easylogging/easyloggingpp#vmodule" << endl;
+        return s.str();
+      } else {
+        return string();
+      }
+    }
+  }  // ::pfasst::config
+}  // ::pfasst

--- a/include/pfasst/controller_impl.hpp
+++ b/include/pfasst/controller_impl.hpp
@@ -1,0 +1,221 @@
+#include "controller.hpp"
+
+#include "config.hpp"
+
+
+namespace pfasst
+{
+  template<typename time>
+  Controller<time>::Controller()
+    :   step(0)
+      , iteration(0)
+      , max_iterations(0)
+      , t(0.0)
+      , dt(0.0)
+      , tend(0.0)
+  {}
+
+  template<typename time>
+  Controller<time>::~Controller()
+  {}
+
+  template<typename time>
+  void Controller<time>::set_options(bool all_sweepers)
+  {
+    this->tend = config::get_value<double>("tend", this->tend);
+    this->dt = config::get_value<double>("dt", this->dt);
+    this->max_iterations = config::get_value<size_t>("num_iters", this->max_iterations);
+
+    // XXX: add some nice "nsteps" logic here
+
+    if (all_sweepers) {
+      for (auto l = coarsest(); l <= finest(); ++l) {
+        l.current()->set_options();
+      }
+    }
+  }
+
+  template<typename time>
+  void Controller<time>::setup()
+  {
+    for (auto l = coarsest(); l <= finest(); ++l) {
+      l.current()->set_controller(this);
+      l.current()->setup();
+    }
+  }
+
+  template<typename time>
+  void Controller<time>::set_duration(time t0, time tend, time dt, size_t niters)
+  {
+    this->t = t0;
+    this->tend = tend;
+    this->dt = dt;
+    this->step = 0;
+    this->iteration = 0;
+    this->max_iterations = niters;
+  }
+
+  template<typename time>
+  void Controller<time>::add_level(shared_ptr<ISweeper<time>> swpr,
+                                   shared_ptr<ITransfer<time>> trnsfr,
+                                   bool coarse)
+  {
+    if (coarse) {
+      levels.push_front(swpr);
+      transfer.push_front(trnsfr);
+    } else {
+      levels.push_back(swpr);
+      transfer.push_back(trnsfr);
+    }
+  }
+
+  template<typename time>
+  size_t Controller<time>::nlevels()
+  {
+    return levels.size();
+  }
+
+  //! @{
+  template<typename time>
+  size_t Controller<time>::get_step()
+  {
+    return step;
+  }
+
+  template<typename time>
+  void Controller<time>::set_step(size_t n)
+  {
+    t += (n - step) * dt;
+    step = n;
+  }
+
+  template<typename time>
+  time Controller<time>::get_time_step()
+  {
+    return dt;
+  }
+
+  template<typename time>
+  time Controller<time>::get_time()
+  {
+    return t;
+  }
+
+  template<typename time>
+  void Controller<time>::advance_time(size_t nsteps)
+  {
+    step += nsteps;
+    t += nsteps * dt;
+  }
+
+  template<typename time>
+  time Controller<time>::get_end_time()
+  {
+    return tend;
+  }
+
+  template<typename time>
+  size_t Controller<time>::get_iteration()
+  {
+    return iteration;
+  }
+
+  template<typename time>
+  void Controller<time>::set_iteration(size_t iter)
+  {
+    this->iteration = iter;
+  }
+
+  template<typename time>
+  void Controller<time>::advance_iteration()
+  {
+    iteration++;
+  }
+
+  template<typename time>
+  size_t Controller<time>::get_max_iterations()
+  {
+    return max_iterations;
+  }
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::finest()
+  {
+    return Controller<time>::LevelIter(nlevels() - 1, this);
+  }
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::coarsest()
+  {
+    return Controller<time>::LevelIter(0, this);
+  }
+
+
+  template<typename time>
+  Controller<time>::LevelIter::LevelIter(int level, Controller* ts)
+    :   ts(ts)
+      , level(level)
+  {}
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::LevelIter::operator++()
+  {
+    level++;
+    return *this;
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator==(typename Controller<time>::LevelIter i)
+  {
+    return level == i.level;
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator!=(typename Controller<time>::LevelIter i)
+  {
+    return level != i.level;
+  }
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::LevelIter::operator--()
+  {
+    level--;
+    return *this;
+  }
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::LevelIter::operator-(difference_type i)
+  {
+    return LevelIter(level - i, ts);
+  }
+
+  template<typename time>
+  typename Controller<time>::LevelIter Controller<time>::LevelIter::operator+(difference_type i)
+  {
+    return LevelIter(level + i, ts);
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator<=(typename Controller<time>::LevelIter i)
+  {
+    return level <= i.level;
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator>=(typename Controller<time>::LevelIter i)
+  {
+    return level >= i.level;
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator<(typename Controller<time>::LevelIter i)
+  {
+    return level < i.level;
+  }
+
+  template<typename time>
+  bool Controller<time>::LevelIter::operator>(typename Controller<time>::LevelIter i)
+  {
+    return level > i.level;
+  }
+}  // ::pfasst

--- a/include/pfasst/encap/encap_sweeper_impl.hpp
+++ b/include/pfasst/encap/encap_sweeper_impl.hpp
@@ -1,0 +1,240 @@
+#include "encap_sweeper.hpp"
+
+#include <algorithm>
+#include <cassert>
+using namespace std;
+
+#include "../globals.hpp"
+#include "../config.hpp"
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename time>
+    EncapSweeper<time>::EncapSweeper()
+      :   quadrature(nullptr)
+        , abs_residual_tol(0.0)
+        , rel_residual_tol(0.0)
+    {}
+
+    template<typename time>
+    shared_ptr<Encapsulation<time>> EncapSweeper<time>::get_state(size_t m) const
+    {
+      return this->state[m];
+    }
+
+    template<typename time>
+    shared_ptr<Encapsulation<time>> EncapSweeper<time>::get_tau(size_t m) const
+    {
+      return this->fas_corrections[m];
+    }
+
+    template<typename time>
+    shared_ptr<Encapsulation<time>> EncapSweeper<time>::get_saved_state(size_t m) const
+    {
+      return this->saved_state[m];
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::set_options()
+    {
+      this->abs_residual_tol = time(config::get_value<double>("abs_res_tol", this->abs_residual_tol));
+      this->rel_residual_tol = time(config::get_value<double>("rel_res_tol", this->rel_residual_tol));
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::setup(bool coarse)
+    {
+      auto const nodes = this->quadrature->get_nodes();
+      auto const num_nodes = this->quadrature->get_num_nodes();
+
+      this->start_state = this->get_factory()->create(pfasst::encap::solution);
+      this->end_state = this->get_factory()->create(pfasst::encap::solution);
+
+      for (size_t m = 0; m < num_nodes; m++) {
+        this->state.push_back(this->get_factory()->create(pfasst::encap::solution));
+        if (coarse) {
+          this->saved_state.push_back(this->get_factory()->create(pfasst::encap::solution));
+        }
+      }
+
+      if (coarse) {
+        for (size_t m = 0; m < num_nodes; m++) {
+          this->fas_corrections.push_back(this->get_factory()->create(pfasst::encap::solution));
+        }
+      }
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::spread()
+    {
+      for (size_t m = 1; m < this->quadrature->get_num_nodes(); m++) {
+        this->state[m]->copy(this->state[0]);
+      }
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::save(bool initial_only)
+    {
+      // XXX: if !left_is_node, this is a problem...
+      if (initial_only) {
+        this->saved_state[0]->copy(state[0]);
+      } else {
+        for (size_t m = 0; m < this->saved_state.size(); m++) {
+          this->saved_state[m]->copy(state[m]);
+        }
+      }
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::set_quadrature(shared_ptr<IQuadrature<time>> quadrature)
+    {
+      this->quadrature = quadrature;
+    }
+
+    template<typename time>
+    shared_ptr<const IQuadrature<time>> EncapSweeper<time>::get_quadrature() const
+    {
+      return this->quadrature;
+    }
+
+    template<typename time>
+    shared_ptr<Encapsulation<time>> EncapSweeper<time>::get_start_state() const
+    {
+      return this->start_state;
+    }
+
+    template<typename time>
+    const vector<time> EncapSweeper<time>::get_nodes() const
+    {
+      return this->quadrature->get_nodes();
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::set_factory(shared_ptr<EncapFactory<time>> factory)
+    {
+      this->factory = factory;
+    }
+
+    template<typename time>
+    shared_ptr<EncapFactory<time>> EncapSweeper<time>::get_factory() const
+    {
+      return factory;
+    }
+
+    template<typename time>
+    shared_ptr<Encapsulation<time>> EncapSweeper<time>::get_end_state()
+    {
+      return this->end_state;
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::advance()
+    {
+      throw NotImplementedYet("sweeper");
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::reevaluate(bool initial_only)
+    {
+      UNUSED(initial_only);
+      throw NotImplementedYet("sweeper");
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::integrate(time dt, vector<shared_ptr<Encapsulation<time>>> dst) const
+    {
+      UNUSED(dt); UNUSED(dst);
+      throw NotImplementedYet("sweeper");
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::set_residual_tolerances(time abs_residual_tol, time rel_residual_tol, int order)
+    {
+      this->abs_residual_tol = abs_residual_tol;
+      this->rel_residual_tol = rel_residual_tol;
+      this->residual_norm_order = order;
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::residual(time dt, vector<shared_ptr<Encapsulation<time>>> dst) const
+    {
+      UNUSED(dt); UNUSED(dst);
+      throw NotImplementedYet("residual");
+    }
+
+    template<typename time>
+    bool EncapSweeper<time>::converged()
+    {
+      if (this->abs_residual_tol > 0.0 || this->rel_residual_tol > 0.0) {
+        if (this->residuals.size() == 0) {
+          for (size_t m = 0; m < this->get_nodes().size(); m++) {
+            this->residuals.push_back(this->get_factory()->create(pfasst::encap::solution));
+          }
+        }
+        this->residual(this->get_controller()->get_time_step(), this->residuals);
+        vector<time> anorms, rnorms;
+        for (size_t m = 0; m < this->get_nodes().size(); m++) {
+          anorms.push_back(this->residuals[m]->norm0());
+          rnorms.push_back(anorms.back() / this->get_state(m)->norm0());
+        }
+        auto amax = *std::max_element(anorms.begin(), anorms.end());
+        auto rmax = *std::max_element(rnorms.begin(), rnorms.end());
+        if (amax < this->abs_residual_tol || rmax < this->rel_residual_tol) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::post(ICommunicator* comm, int tag)
+    {
+      this->start_state->post(comm, tag);
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::send(ICommunicator* comm, int tag, bool blocking)
+    {
+      this->end_state->send(comm, tag, blocking);
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::recv(ICommunicator* comm, int tag, bool blocking)
+    {
+      this->start_state->recv(comm, tag, blocking);
+      if (this->quadrature->left_is_node()) {
+        this->state[0]->copy(this->start_state);
+      }
+    }
+
+    template<typename time>
+    void EncapSweeper<time>::broadcast(ICommunicator* comm)
+    {
+      if (comm->rank() == comm->size() - 1) {
+        this->start_state->copy(this->end_state);
+      }
+      this->start_state->broadcast(comm);
+    }
+
+
+    template<typename time>
+    EncapSweeper<time>& as_encap_sweeper(shared_ptr<ISweeper<time>> x)
+    {
+      shared_ptr<EncapSweeper<time>> y = dynamic_pointer_cast<EncapSweeper<time>>(x);
+      assert(y);
+      return *y.get();
+    }
+
+    template<typename time>
+    const EncapSweeper<time>& as_encap_sweeper(shared_ptr<const ISweeper<time>> x)
+    {
+      shared_ptr<const EncapSweeper<time>> y = dynamic_pointer_cast<const EncapSweeper<time>>(x);
+      assert(y);
+      return *y.get();
+    }
+
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/encap/encapsulation_impl.hpp
+++ b/include/pfasst/encap/encapsulation_impl.hpp
@@ -1,0 +1,90 @@
+#include "encapsulation.hpp"
+
+
+#include "../globals.hpp"
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename time>
+    Encapsulation<time>::~Encapsulation()
+    {}
+
+    template<typename time>
+    void Encapsulation<time>::post(ICommunicator* comm, int tag)
+    {
+      UNUSED(comm); UNUSED(tag);
+    }
+
+    template<typename time>
+    void Encapsulation<time>::send(ICommunicator* comm, int tag, bool blocking)
+    {
+      UNUSED(comm); UNUSED(tag); UNUSED(blocking);
+      throw NotImplementedYet("pfasst");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::recv(ICommunicator* comm, int tag, bool blocking)
+    {
+      UNUSED(comm); UNUSED(tag); UNUSED(blocking);
+      throw NotImplementedYet("pfasst");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::broadcast(ICommunicator* comm)
+    {
+      UNUSED(comm);
+      throw NotImplementedYet("pfasst");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::zero()
+    {
+      throw NotImplementedYet("encap");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::copy(shared_ptr<const Encapsulation<time>>)
+    {
+      throw NotImplementedYet("encap");
+    }
+
+    template<typename time>
+    time Encapsulation<time>::norm0() const
+    {
+      throw NotImplementedYet("norm0");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::saxpy(time a, shared_ptr<const Encapsulation<time>> x)
+    {
+      UNUSED(a); UNUSED(x);
+      throw NotImplementedYet("encap");
+    }
+
+    template<typename time>
+    void Encapsulation<time>::mat_apply(vector<shared_ptr<Encapsulation<time>>> dst,
+                                        time a, Matrix<time> mat,
+                                        vector<shared_ptr<Encapsulation<time>>> src,
+                                        bool zero)
+    {
+      size_t ndst = dst.size();
+      size_t nsrc = src.size();
+
+      if (zero) {
+        for (auto elem : dst) { elem->zero(); }
+      }
+
+      for (size_t n = 0; n < ndst; n++) {
+        for (size_t m = 0; m < nsrc; m++) {
+          auto s = mat(n, m);
+          if (s != 0.0) {
+            dst[n]->saxpy(a*s, src[m]);
+          }
+        }
+      }
+    }
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/encap/imex_sweeper_impl.hpp
+++ b/include/pfasst/encap/imex_sweeper_impl.hpp
@@ -1,0 +1,313 @@
+#include "imex_sweeper.hpp"
+
+#include <cassert>
+using namespace std;
+
+#include "../globals.hpp"
+#include "../logging.hpp"
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename time>
+    void IMEXSweeper<time>::integrate_end_state(time dt)
+    {
+      vector<shared_ptr<Encapsulation<time>>> dst = { this->end_state };
+      dst[0]->copy(this->start_state);
+      dst[0]->mat_apply(dst, dt, this->quadrature->get_b_mat(), this->fs_expl, false);
+      dst[0]->mat_apply(dst, dt, this->quadrature->get_b_mat(), this->fs_impl, false);
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::setup(bool coarse)
+    {
+      pfasst::encap::EncapSweeper<time>::setup(coarse);
+
+      auto const num_nodes = this->quadrature->get_num_nodes();
+      auto const num_s_integrals = this->quadrature->left_is_node() ? num_nodes - 1 : num_nodes;
+
+      for (size_t m = 0; m < num_nodes; m++) {
+        this->fs_expl.push_back(this->get_factory()->create(pfasst::encap::function));
+        this->fs_impl.push_back(this->get_factory()->create(pfasst::encap::function));
+      }
+      for (size_t m = 0; m < num_s_integrals; m++) {
+        this->s_integrals.push_back(this->get_factory()->create(pfasst::encap::solution));
+      }
+
+      if (! this->quadrature->left_is_node()) {
+        this->fs_expl_start = this->get_factory()->create(pfasst::encap::function);
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::predict(bool initial)
+    {
+      if (this->quadrature->left_is_node()) {
+        this->predict_with_left(initial);
+      } else {
+        this->predict_without_left(initial);
+      }
+
+      if (this->quadrature->right_is_node()) {
+        this->end_state->copy(this->state.back());
+      } else {
+        this->integrate_end_state(this->get_controller()->get_time_step());
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::sweep()
+    {
+      if (this->quadrature->left_is_node()) {
+        this->sweep_with_left();
+      } else {
+        this->sweep_without_left();
+      }
+
+      if (this->quadrature->right_is_node()) {
+        this->end_state->copy(this->state.back());
+      } else {
+        this->integrate_end_state(this->get_controller()->get_time_step());
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::advance()
+    {
+      this->start_state->copy(this->end_state);
+      if (this->quadrature->left_is_node() && this->quadrature->right_is_node()) {
+        this->state[0]->copy(this->start_state);
+        this->fs_expl.front()->copy(this->fs_expl.back());
+        this->fs_impl.front()->copy(this->fs_impl.back());
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::reevaluate(bool initial_only)
+    {
+      time t0 = this->get_controller()->get_time();
+      time dt = this->get_controller()->get_time_step();
+      if (initial_only) {
+        if (this->quadrature->left_is_node()) {
+          this->f_expl_eval(this->fs_expl[0], this->state[0], t0);
+          this->f_impl_eval(this->fs_impl[0], this->state[0], t0);
+        } else {
+          throw NotImplementedYet("reevaluate");
+        }
+      } else {
+        for (size_t m = 0; m < this->quadrature->get_num_nodes(); m++) {
+          time t =  t0 + dt * this->quadrature->get_nodes()[m];
+          this->f_expl_eval(this->fs_expl[m], this->state[m], t);
+          this->f_impl_eval(this->fs_impl[m], this->state[m], t);
+        }
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::integrate(time dt, vector<shared_ptr<Encapsulation<time>>> dst) const
+    {
+      auto const q_mat = this->quadrature->get_q_mat();
+      dst[0]->mat_apply(dst, dt, q_mat, this->fs_expl, true);
+      dst[0]->mat_apply(dst, dt, q_mat, this->fs_impl, false);
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::residual(time dt, vector<shared_ptr<Encapsulation<time>>> dst) const
+    {
+      for (size_t m = 0; m < this->quadrature->get_num_nodes(); m++) {
+        dst[m]->copy(this->start_state);
+        dst[m]->saxpy(-1.0, this->state[m]);
+      }
+      if (this->fas_corrections.size() > 0) {
+        // XXX: build a matrix and use mat_apply to do this
+        for (size_t m = 0; m < this->quadrature->get_num_nodes(); m++) {
+          for (size_t n = 0; n <= m; n++) {
+            dst[m]->saxpy(1.0, this->fas_corrections[n]);
+          }
+        }
+      }
+      dst[0]->mat_apply(dst, dt, this->quadrature->get_q_mat(), this->fs_expl, false);
+      dst[0]->mat_apply(dst, dt, this->quadrature->get_q_mat(), this->fs_impl, false);
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::f_expl_eval(shared_ptr<Encapsulation<time>> f_expl_encap,
+                                        shared_ptr<Encapsulation<time>> u_encap,
+                                        time t)
+    {
+      UNUSED(f_expl_encap); UNUSED(u_encap); UNUSED(t);
+      throw NotImplementedYet("imex (f_expl_eval)");
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::f_impl_eval(shared_ptr<Encapsulation<time>> f_impl_encap,
+                                        shared_ptr<Encapsulation<time>> u_encap,
+                                        time t)
+    {
+      UNUSED(f_impl_encap); UNUSED(u_encap); UNUSED(t);
+      throw NotImplementedYet("imex (f_impl_eval)");
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::impl_solve(shared_ptr<Encapsulation<time>> f_encap,
+                                       shared_ptr<Encapsulation<time>> u_encap,
+                                       time t, time dt,
+                                       shared_ptr<Encapsulation<time>> rhs_encap)
+    {
+      UNUSED(f_encap); UNUSED(u_encap); UNUSED(t); UNUSED(dt); UNUSED(rhs_encap);
+      throw NotImplementedYet("imex (impl_solve)");
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::predict_with_left(bool initial)
+    {
+      time dt = this->get_controller()->get_time_step();
+      time t  = this->get_controller()->get_time();
+      CLOG(INFO, "Sweeper") << "predicting step " << this->get_controller()->get_step() + 1
+                            << " (t=" << t << ", dt=" << dt << ")";
+
+      if (initial) {
+        this->state[0]->copy(this->start_state);
+        this->f_expl_eval(this->fs_expl[0], this->state[0], t);
+        this->f_impl_eval(this->fs_impl[0], this->state[0], t);
+      }
+
+      shared_ptr<Encapsulation<time>> rhs = this->get_factory()->create(pfasst::encap::solution);
+
+      auto const nodes = this->quadrature->get_nodes();
+
+      // step across all nodes
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        time ds = dt * (nodes[m+1] - nodes[m]);
+        rhs->copy(this->state[m]);
+        rhs->saxpy(ds, this->fs_expl[m]);
+        this->impl_solve(this->fs_impl[m + 1], this->state[m + 1], t, ds, rhs);
+        this->f_expl_eval(this->fs_expl[m + 1], this->state[m + 1], t + ds);
+        t += ds;
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::predict_without_left(bool initial)
+    {
+      UNUSED(initial);
+      time dt = this->get_controller()->get_time_step();
+      time t  = this->get_controller()->get_time();
+      CLOG(INFO, "Sweeper") << "predicting step " << this->get_controller()->get_step() + 1
+                            << " (t=" << t << ", dt=" << dt << ")";
+      time ds;
+
+      shared_ptr<Encapsulation<time>> rhs = this->get_factory()->create(pfasst::encap::solution);
+
+      auto const nodes = this->quadrature->get_nodes();
+
+      // step to first node
+      ds = dt * nodes[0];
+      this->f_expl_eval(this->fs_expl_start, this->start_state, t);
+      rhs->copy(this->start_state);
+      rhs->saxpy(ds, this->fs_expl_start);
+      this->impl_solve(this->fs_impl[0], this->state[0], t, ds, rhs);
+      this->f_expl_eval(this->fs_expl[0], this->state[0], t + ds);
+
+      // step across all nodes
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        ds = dt * (nodes[m+1] - nodes[m]);
+        rhs->copy(this->state[m]);
+        rhs->saxpy(ds, this->fs_expl[m]);
+        this->impl_solve(this->fs_impl[m+1], this->state[m+1], t, ds, rhs);
+        this->f_expl_eval(this->fs_expl[m+1], this->state[m+1], t + ds);
+        t += ds;
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::sweep_with_left()
+    {
+      auto const nodes = this->quadrature->get_nodes();
+      auto const dt    = this->get_controller()->get_time_step();
+      auto const s_mat = this->quadrature->get_s_mat().block(1, 0, nodes.size()-1, nodes.size());
+      CLOG(INFO, "Sweeper") << "sweeping on step " << this->get_controller()->get_step() + 1
+                            << " in iteration " << this->get_controller()->get_iteration() << " (dt=" << dt << ")";
+      time ds;
+
+      this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_expl, true);
+      this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_impl, false);
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        ds = dt * (nodes[m+1] - nodes[m]);
+        this->s_integrals[m]->saxpy(-ds, this->fs_expl[m]);
+        this->s_integrals[m]->saxpy(-ds, this->fs_impl[m+1]);
+      }
+      if (this->fas_corrections.size() > 0) {
+        for (size_t m = 0; m < this->s_integrals.size(); m++) {
+          this->s_integrals[m]->saxpy(1.0, this->fas_corrections[m+1]);
+        }
+      }
+
+      shared_ptr<Encapsulation<time>> rhs = this->get_factory()->create(pfasst::encap::solution);
+
+      // step across all nodes
+      auto t = this->get_controller()->get_time();
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        ds = dt * (nodes[m+1] - nodes[m]);
+        rhs->copy(this->state[m]);
+        rhs->saxpy(ds, this->fs_expl[m]);
+        rhs->saxpy(1.0, this->s_integrals[m]);
+        this->impl_solve(this->fs_impl[m + 1], this->state[m + 1], t, ds, rhs);
+        this->f_expl_eval(this->fs_expl[m + 1], this->state[m + 1], t + ds);
+        t += ds;
+      }
+    }
+
+    template<typename time>
+    void IMEXSweeper<time>::sweep_without_left()
+    {
+      auto const nodes = this->quadrature->get_nodes();
+      auto const dt    = this->get_controller()->get_time_step();
+      auto const s_mat = this->quadrature->get_s_mat();
+      CLOG(INFO, "Sweeper") << "sweeping on step " << this->get_controller()->get_step() + 1
+                            << " in iteration " << this->get_controller()->get_iteration() << " (dt=" << dt << ")";
+      time ds;
+
+      this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_expl, true);
+      this->s_integrals[0]->mat_apply(this->s_integrals, dt, s_mat, this->fs_impl, false);
+      ds = dt * nodes[0];
+      this->s_integrals[0]->saxpy(-ds, this->fs_expl_start);
+      this->s_integrals[0]->saxpy(-ds, this->fs_impl[0]);
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        ds = dt * (nodes[m+1] - nodes[m]);
+        this->s_integrals[m+1]->saxpy(-ds, this->fs_expl[m]);
+        this->s_integrals[m+1]->saxpy(-ds, this->fs_impl[m+1]);
+      }
+      if (this->fas_corrections.size() > 0) {
+        for (size_t m = 0; m < this->s_integrals.size(); m++) {
+          this->s_integrals[m]->saxpy(1.0, this->fas_corrections[m]);
+        }
+      }
+
+      shared_ptr<Encapsulation<time>> rhs = this->get_factory()->create(pfasst::encap::solution);
+
+      // step to first node
+      auto t = this->get_controller()->get_time();
+      ds = dt * nodes[0];
+      this->f_expl_eval(this->fs_expl_start, this->start_state, t);
+      rhs->copy(this->start_state);
+      rhs->saxpy(ds, this->fs_expl_start);
+      rhs->saxpy(1.0, this->s_integrals[0]);
+      this->impl_solve(this->fs_impl[0], this->state[0], t, ds, rhs);
+      this->f_expl_eval(this->fs_expl[0], this->state[0], t + ds);
+
+      // step across all nodes
+      for (size_t m = 0; m < nodes.size() - 1; ++m) {
+        ds = dt * (nodes[m+1] - nodes[m]);
+        rhs->copy(this->state[m]);
+        rhs->saxpy(ds, this->fs_expl[m]);
+        rhs->saxpy(1.0, this->s_integrals[m+1]);
+        this->impl_solve(this->fs_impl[m+1], this->state[m+1], t, ds, rhs);
+        this->f_expl_eval(this->fs_expl[m+1], this->state[m+1], t + ds);
+        t += ds;
+      }
+    }
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/encap/mpi_vector.hpp
+++ b/include/pfasst/encap/mpi_vector.hpp
@@ -1,26 +1,21 @@
-/*
- * MPI enabled vector.
- */
-
 #ifndef _PFASST_MPI_VECTOR_HPP_
 #define _PFASST_MPI_VECTOR_HPP_
-
-#include <cassert>
 
 #include <mpi.h>
 
 #include "vector.hpp"
 #include "../mpi_communicator.hpp"
 
-using namespace std;
 
 namespace pfasst
 {
   namespace encap
   {
-
     using namespace pfasst::mpi;
 
+    /**
+     * MPI enabled vector.
+     */
     template<typename scalar, typename time = time_precision>
     class MPIVectorEncapsulation
       : public VectorEncapsulation<scalar, time>
@@ -41,103 +36,31 @@ namespace pfasst
 
       public:
         //! @{
-        MPIVectorEncapsulation(int size)
-          : VectorEncapsulation<scalar, time>(size)
-        {}
-
-        virtual ~MPIVectorEncapsulation()
-        {}
+        MPIVectorEncapsulation(const size_t size);
+        virtual ~MPIVectorEncapsulation() = default;
         //! @}
 
         //! @{
-        void post(ICommunicator* comm, int tag) override
-        {
-          auto& mpi = as_mpi(comm);
-          if (mpi.size() == 1) { return; }
-          if (mpi.rank() == 0) { return; }
-
-          int err = MPI_Irecv(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
-                              (mpi.rank() - 1) % mpi.size(), tag, mpi.comm, &recv_request);
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-        }
-
-        virtual void recv(ICommunicator* comm, int tag, bool blocking) override
-        {
-          auto& mpi = as_mpi(comm);
-          if (mpi.size() == 1) { return; }
-          if (mpi.rank() == 0) { return; }
-
-          int err;
-          if (blocking) {
-            MPI_Status stat;
-            err = MPI_Recv(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
-                           (mpi.rank() - 1) % mpi.size(), tag, mpi.comm, &stat);
-          } else {
-            MPI_Status stat;
-            err = MPI_Wait(&recv_request, &stat);
-          }
-
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-        }
-
-        virtual void send(ICommunicator* comm, int tag, bool blocking) override
-        {
-          auto& mpi = as_mpi(comm);
-          if (mpi.size() == 1) { return; }
-          if (mpi.rank() == mpi.size() - 1) { return; }
-
-          int err = MPI_SUCCESS;
-          if (blocking) {
-            err = MPI_Send(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
-                           (mpi.rank() + 1) % mpi.size(), tag, mpi.comm);
-          } else {
-            MPI_Status stat;
-            err = MPI_Wait(&send_request, &stat);
-            if (err != MPI_SUCCESS) {
-              throw MPIError();
-            }
-
-            err = MPI_Isend(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
-                            (mpi.rank() + 1) % mpi.size(), tag, mpi.comm, &send_request);
-          }
-
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-        }
-
-        virtual void broadcast(ICommunicator* comm) override
-        {
-          auto& mpi = as_mpi(comm);
-          int err = MPI_Bcast(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
-                              comm->size()-1, mpi.comm);
-
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-        }
+        virtual void post(ICommunicator* comm, int tag) override;
+        virtual void recv(ICommunicator* comm, int tag, bool blocking) override;
+        virtual void send(ICommunicator* comm, int tag, bool blocking) override;
+        virtual void broadcast(ICommunicator* comm) override;
         //! @}
     };
 
+
     template<typename scalar, typename time = time_precision>
     class MPIVectorFactory
-      : public EncapFactory<time>
+      : public VectorFactory<scalar, time>
     {
-        int size;
       public:
-        int dofs() { return size; }
-        MPIVectorFactory(const int size) : size(size) { }
-        shared_ptr<Encapsulation<time>> create(const EncapType)
-        {
-          return make_shared<MPIVectorEncapsulation<scalar, time>>(size);
-        }
+        MPIVectorFactory(const size_t size);
+        virtual shared_ptr<Encapsulation<time>> create(const EncapType) override;
     };
 
   }  // ::pfasst::encap
 }  // ::pfasst
+
+#include "mpi_vector_impl.hpp"
 
 #endif

--- a/include/pfasst/encap/mpi_vector_impl.hpp
+++ b/include/pfasst/encap/mpi_vector_impl.hpp
@@ -1,0 +1,103 @@
+#include "mpi_vector.hpp"
+
+#include <cassert>
+using namespace std;
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename scalar, typename time>
+    MPIVectorEncapsulation<scalar, time>::MPIVectorEncapsulation(const size_t size)
+      : VectorEncapsulation<scalar, time>(size)
+    {}
+
+    template<typename scalar, typename time>
+    void MPIVectorEncapsulation<scalar, time>::post(ICommunicator* comm, int tag)
+    {
+      auto& mpi = as_mpi(comm);
+      if (mpi.size() == 1) { return; }
+      if (mpi.rank() == 0) { return; }
+
+      int err = MPI_Irecv(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
+                          (mpi.rank() - 1) % mpi.size(), tag, mpi.comm, &recv_request);
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+    }
+
+    template<typename scalar, typename time>
+    void MPIVectorEncapsulation<scalar, time>::recv(ICommunicator* comm, int tag, bool blocking)
+    {
+      auto& mpi = as_mpi(comm);
+      if (mpi.size() == 1) { return; }
+      if (mpi.rank() == 0) { return; }
+
+      int err;
+      if (blocking) {
+        MPI_Status stat;
+        err = MPI_Recv(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
+                       (mpi.rank() - 1) % mpi.size(), tag, mpi.comm, &stat);
+      } else {
+        MPI_Status stat;
+        err = MPI_Wait(&recv_request, &stat);
+      }
+
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+    }
+
+    template<typename scalar, typename time>
+    void MPIVectorEncapsulation<scalar, time>::send(ICommunicator* comm, int tag, bool blocking)
+    {
+      auto& mpi = as_mpi(comm);
+      if (mpi.size() == 1) { return; }
+      if (mpi.rank() == mpi.size() - 1) { return; }
+
+      int err = MPI_SUCCESS;
+      if (blocking) {
+        err = MPI_Send(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
+                       (mpi.rank() + 1) % mpi.size(), tag, mpi.comm);
+      } else {
+        MPI_Status stat;
+        err = MPI_Wait(&send_request, &stat);
+        if (err != MPI_SUCCESS) {
+          throw MPIError();
+        }
+
+        err = MPI_Isend(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
+                        (mpi.rank() + 1) % mpi.size(), tag, mpi.comm, &send_request);
+      }
+
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+    }
+
+    template<typename scalar, typename time>
+    void MPIVectorEncapsulation<scalar, time>::broadcast(ICommunicator* comm)
+    {
+      auto& mpi = as_mpi(comm);
+      int err = MPI_Bcast(this->data(), sizeof(scalar) * this->size(), MPI_CHAR,
+                          comm->size()-1, mpi.comm);
+
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+    }
+
+
+    template<typename scalar, typename time>
+    MPIVectorFactory<scalar, time>::MPIVectorFactory(const size_t size)
+      : pfasst::encap::VectorFactory<scalar, time>(size)
+    {}
+
+    template<typename scalar, typename time>
+    shared_ptr<Encapsulation<time>> MPIVectorFactory<scalar, time>::create(const EncapType)
+    {
+      return make_shared<MPIVectorEncapsulation<scalar, time>>(this->dofs());
+    }
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/encap/poly_interp.hpp
+++ b/include/pfasst/encap/poly_interp.hpp
@@ -1,28 +1,26 @@
-/*
- * Polynomial time interpolation mixin.
- */
-
 #ifndef _PFASST_ENCAP_POLYINTERP_HPP_
 #define _PFASST_ENCAP_POLYINTERP_HPP_
 
-#include <vector>
-#include <cassert>
 #include <memory>
+#include <vector>
+using namespace std;
 
-#include "../globals.hpp"
 #include "../interfaces.hpp"
-#include "../quadrature.hpp"
-#include "encap_sweeper.hpp"
+#include "encapsulation.hpp"
+
 
 namespace pfasst
 {
   namespace encap
   {
-
+    /**
+     * Polynomial time interpolation mixin.
+     */
     template<typename time = time_precision>
     class PolyInterpMixin
       : public pfasst::ITransfer<time>
     {
+      protected:
         //! @{
         typedef vector<shared_ptr<Encapsulation<time>>> EncapVecT;
         Matrix<time> tmat;
@@ -31,188 +29,37 @@ namespace pfasst
 
       public:
         //! @{
-        virtual ~PolyInterpMixin()
-        {}
+        virtual ~PolyInterpMixin();
         //! @}
 
         //! @{
         virtual void interpolate_initial(shared_ptr<ISweeper<time>> dst,
-                                         shared_ptr<const ISweeper<time>> src) override
-        {
-          auto& fine = as_encap_sweeper(dst);
-          auto& crse = as_encap_sweeper(src);
-
-          auto crse_factory = crse.get_factory();
-          auto fine_factory = fine.get_factory();
-
-          auto crse_delta = crse_factory->create(solution);
-          this->restrict(crse_delta, fine.get_start_state());
-          crse_delta->saxpy(-1.0, crse.get_start_state());
-
-          auto fine_delta = fine_factory->create(solution);
-          this->interpolate(fine_delta, crse_delta);
-          fine.get_start_state()->saxpy(-1.0, fine_delta);
-
-          fine.reevaluate(true);
-        }
-
-
+                                         shared_ptr<const ISweeper<time>> src) override;
         virtual void interpolate(shared_ptr<ISweeper<time>> dst,
                                  shared_ptr<const ISweeper<time>> src,
-                                 bool interp_initial) override
-        {
-          auto& fine = as_encap_sweeper(dst);
-          auto& crse = as_encap_sweeper(src);
-
-          if (tmat.rows() == 0) {
-            tmat = pfasst::quadrature::compute_interp<time>(fine.get_nodes(), crse.get_nodes());
-          }
-
-          if (interp_initial) {
-            this->interpolate_initial(dst, src);
-          }
-
-          size_t nfine = fine.get_nodes().size();
-          size_t ncrse = crse.get_nodes().size();
-
-          auto crse_factory = crse.get_factory();
-          auto fine_factory = fine.get_factory();
-
-          EncapVecT fine_state(nfine), fine_delta(ncrse);
-
-          for (size_t m = 0; m < nfine; m++) { fine_state[m] = fine.get_state(m); }
-          for (size_t m = 0; m < ncrse; m++) { fine_delta[m] = fine_factory->create(solution); }
-
-          auto crse_delta = crse_factory->create(solution);
-          for (size_t m = 0; m < ncrse; m++) {
-            crse_delta->copy(crse.get_state(m));
-            crse_delta->saxpy(-1.0, crse.get_saved_state(m));
-            interpolate(fine_delta[m], crse_delta);
-          }
-
-          fine.get_state(0)->mat_apply(fine_state, 1.0, tmat, fine_delta, false);
-
-          fine.reevaluate();
-        }
-
-
+                                 bool interp_initial) override;
         virtual void interpolate(shared_ptr<Encapsulation<time>> dst,
-                                 shared_ptr<const Encapsulation<time>> src)
-        {
-          UNUSED(dst); UNUSED(src);
-          throw NotImplementedYet("mlsdc/pfasst");
-        }
+                                 shared_ptr<const Encapsulation<time>> src);
         //! @}
-
 
         //! @{
         virtual void restrict_initial(shared_ptr<ISweeper<time>> dst,
-                                      shared_ptr<const ISweeper<time>> src) override
-        {
-          auto& crse = as_encap_sweeper(dst);
-          auto& fine = as_encap_sweeper(src);
-          this->restrict(crse.get_start_state(), fine.get_start_state());
-          crse.reevaluate(true);
-        }
-
-
+                                      shared_ptr<const ISweeper<time>> src) override;
         virtual void restrict(shared_ptr<ISweeper<time>> dst,
                               shared_ptr<const ISweeper<time>> src,
-                              bool restrict_initial) override
-        {
-          auto& crse = pfasst::encap::as_encap_sweeper(dst);
-          auto& fine = pfasst::encap::as_encap_sweeper(src);
-
-          auto const crse_nodes = crse.get_nodes();
-          auto const fine_nodes = fine.get_nodes();
-          auto const num_crse = crse_nodes.size();
-          auto const num_fine = fine_nodes.size();
-
-          if (restrict_initial) {
-            this->restrict_initial(dst, src);
-          }
-
-          int trat = (int(num_fine) - 1) / (int(num_crse) - 1);
-
-          for (size_t m = 0; m < num_crse; m++) {
-            if (crse_nodes[m] != fine_nodes[m * trat]) {
-              throw NotImplementedYet("coarse nodes must be nested");
-            }
-            this->restrict(crse.get_state(m), fine.get_state(m * trat));
-          }
-
-          crse.reevaluate();
-        }
-
-
+                              bool restrict_initial) override;
         virtual void restrict(shared_ptr<Encapsulation<time>> dst,
-                              shared_ptr<const Encapsulation<time>> src)
-        {
-          UNUSED(dst); UNUSED(src);
-          throw NotImplementedYet("mlsdc/pfasst");
-        }
+                              shared_ptr<const Encapsulation<time>> src);
         //! @}
 
+        //! @{
         virtual void fas(time dt, shared_ptr<ISweeper<time>> dst,
-                         shared_ptr<const ISweeper<time>> src) override
-        {
-          auto& crse = pfasst::encap::as_encap_sweeper(dst);
-          auto& fine = pfasst::encap::as_encap_sweeper(src);
-
-          auto const ncrse = crse.get_nodes().size(); assert(ncrse >= 1);
-          auto const nfine = fine.get_nodes().size(); assert(nfine >= 1);
-
-          auto crse_factory = crse.get_factory();
-          auto fine_factory = fine.get_factory();
-
-          EncapVecT crse_int(ncrse), fine_int(nfine), rstr_int(ncrse);
-
-          for (size_t m = 0; m < ncrse; m++) { crse_int[m] = crse_factory->create(solution); }
-          for (size_t m = 0; m < ncrse; m++) { rstr_int[m] = crse_factory->create(solution); }
-          for (size_t m = 0; m < nfine; m++) { fine_int[m] = fine_factory->create(solution); }
-
-          // compute '0 to node' integral on the coarse level
-          crse.integrate(dt, crse_int);
-
-          // compute '0 to node' integral on the fine level
-          fine.integrate(dt, fine_int);
-
-          // restrict '0 to node' fine integral
-          int trat = (int(nfine) - 1) / (int(ncrse) - 1);
-          for (size_t m = 0; m < ncrse; m++) {
-            this->restrict(rstr_int[m], fine_int[m * trat]);
-          }
-
-          // compute 'node to node' tau correction
-          EncapVecT tau(ncrse), rstr_and_crse(2 * ncrse);
-          // Attention: tau is getting filled with pointers to the crse's member
-          for (size_t m = 0; m < ncrse; m++) { tau[m] = crse.get_tau(m); }
-          for (size_t m = 0; m < ncrse; m++) { rstr_and_crse[m] = rstr_int[m]; }
-          for (size_t m = 0; m < ncrse; m++) { rstr_and_crse[ncrse + m] = crse_int[m]; }
-
-          if (fmat.rows() == 0) {
-            fmat.resize(ncrse, 2 * ncrse);
-            fmat.fill(0.0);
-
-            for (size_t m = 0; m < ncrse; m++) {
-              fmat(m, m) = 1.0;
-              fmat(m, ncrse + m) = -1.0;
-
-              // subtract 0-to-(m-1) FAS so resulting FAS is (m-1)-to-m FAS,
-              //  which will be required in the sweeper logic
-              for (size_t n = 0; n < m; n++) {
-                fmat(m, n) = -1.0;
-                fmat(m, ncrse + n) = 1.0;
-              }
-            }
-          }
-
-          tau[0]->mat_apply(tau, 1.0, fmat, rstr_and_crse, true);
-        }
-
+                         shared_ptr<const ISweeper<time>> src) override;
+        //! @}
     };
-
   }  // ::pfasst::encap
 }  // ::pfasst
+
+#include "poly_interp_impl.hpp"
 
 #endif

--- a/include/pfasst/encap/poly_interp_impl.hpp
+++ b/include/pfasst/encap/poly_interp_impl.hpp
@@ -1,0 +1,192 @@
+#include "poly_interp.hpp"
+
+#include <cassert>
+using namespace std;
+
+#include "../globals.hpp"
+#include "../quadrature.hpp"
+#include "encap_sweeper.hpp"
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename time>
+    PolyInterpMixin<time>::~PolyInterpMixin()
+    {}
+
+    template<typename time>
+    void PolyInterpMixin<time>::interpolate_initial(shared_ptr<ISweeper<time>> dst,
+                                                    shared_ptr<const ISweeper<time>> src)
+    {
+      auto& fine = as_encap_sweeper(dst);
+      auto& crse = as_encap_sweeper(src);
+
+      auto crse_factory = crse.get_factory();
+      auto fine_factory = fine.get_factory();
+
+      auto crse_delta = crse_factory->create(solution);
+      this->restrict(crse_delta, fine.get_start_state());
+      crse_delta->saxpy(-1.0, crse.get_start_state());
+
+      auto fine_delta = fine_factory->create(solution);
+      this->interpolate(fine_delta, crse_delta);
+      fine.get_start_state()->saxpy(-1.0, fine_delta);
+
+      fine.reevaluate(true);
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::interpolate(shared_ptr<ISweeper<time>> dst,
+                                            shared_ptr<const ISweeper<time>> src,
+                                            bool interp_initial)
+    {
+      auto& fine = as_encap_sweeper(dst);
+      auto& crse = as_encap_sweeper(src);
+
+      if (tmat.rows() == 0) {
+        tmat = pfasst::quadrature::compute_interp<time>(fine.get_nodes(), crse.get_nodes());
+      }
+
+      if (interp_initial) {
+        this->interpolate_initial(dst, src);
+      }
+
+      size_t nfine = fine.get_nodes().size();
+      size_t ncrse = crse.get_nodes().size();
+
+      auto crse_factory = crse.get_factory();
+      auto fine_factory = fine.get_factory();
+
+      EncapVecT fine_state(nfine), fine_delta(ncrse);
+
+      for (size_t m = 0; m < nfine; m++) { fine_state[m] = fine.get_state(m); }
+      for (size_t m = 0; m < ncrse; m++) { fine_delta[m] = fine_factory->create(solution); }
+
+      auto crse_delta = crse_factory->create(solution);
+      for (size_t m = 0; m < ncrse; m++) {
+        crse_delta->copy(crse.get_state(m));
+        crse_delta->saxpy(-1.0, crse.get_saved_state(m));
+        interpolate(fine_delta[m], crse_delta);
+      }
+
+      fine.get_state(0)->mat_apply(fine_state, 1.0, tmat, fine_delta, false);
+
+      fine.reevaluate();
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::interpolate(shared_ptr<Encapsulation<time>> dst,
+                                            shared_ptr<const Encapsulation<time>> src)
+    {
+      UNUSED(dst); UNUSED(src);
+      throw NotImplementedYet("mlsdc/pfasst");
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::restrict_initial(shared_ptr<ISweeper<time>> dst,
+                                                 shared_ptr<const ISweeper<time>> src)
+    {
+      auto& crse = as_encap_sweeper(dst);
+      auto& fine = as_encap_sweeper(src);
+      this->restrict(crse.get_start_state(), fine.get_start_state());
+      crse.reevaluate(true);
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::restrict(shared_ptr<ISweeper<time>> dst,
+                                         shared_ptr<const ISweeper<time>> src,
+                                         bool restrict_initial)
+    {
+      auto& crse = pfasst::encap::as_encap_sweeper(dst);
+      auto& fine = pfasst::encap::as_encap_sweeper(src);
+
+      auto const crse_nodes = crse.get_nodes();
+      auto const fine_nodes = fine.get_nodes();
+      auto const num_crse = crse_nodes.size();
+      auto const num_fine = fine_nodes.size();
+
+      if (restrict_initial) {
+        this->restrict_initial(dst, src);
+      }
+
+      int trat = (int(num_fine) - 1) / (int(num_crse) - 1);
+
+      for (size_t m = 0; m < num_crse; m++) {
+        if (crse_nodes[m] != fine_nodes[m * trat]) {
+          throw NotImplementedYet("coarse nodes must be nested");
+        }
+        this->restrict(crse.get_state(m), fine.get_state(m * trat));
+      }
+
+      crse.reevaluate();
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::restrict(shared_ptr<Encapsulation<time>> dst,
+                                         shared_ptr<const Encapsulation<time>> src)
+    {
+      UNUSED(dst); UNUSED(src);
+      throw NotImplementedYet("mlsdc/pfasst");
+    }
+
+    template<typename time>
+    void PolyInterpMixin<time>::fas(time dt, shared_ptr<ISweeper<time>> dst,
+                                    shared_ptr<const ISweeper<time>> src)
+    {
+      auto& crse = pfasst::encap::as_encap_sweeper(dst);
+      auto& fine = pfasst::encap::as_encap_sweeper(src);
+
+      auto const ncrse = crse.get_nodes().size(); assert(ncrse >= 1);
+      auto const nfine = fine.get_nodes().size(); assert(nfine >= 1);
+
+      auto crse_factory = crse.get_factory();
+      auto fine_factory = fine.get_factory();
+
+      EncapVecT crse_int(ncrse), fine_int(nfine), rstr_int(ncrse);
+
+      for (size_t m = 0; m < ncrse; m++) { crse_int[m] = crse_factory->create(solution); }
+      for (size_t m = 0; m < ncrse; m++) { rstr_int[m] = crse_factory->create(solution); }
+      for (size_t m = 0; m < nfine; m++) { fine_int[m] = fine_factory->create(solution); }
+
+      // compute '0 to node' integral on the coarse level
+      crse.integrate(dt, crse_int);
+
+      // compute '0 to node' integral on the fine level
+      fine.integrate(dt, fine_int);
+
+      // restrict '0 to node' fine integral
+      int trat = (int(nfine) - 1) / (int(ncrse) - 1);
+      for (size_t m = 0; m < ncrse; m++) {
+        this->restrict(rstr_int[m], fine_int[m * trat]);
+      }
+
+      // compute 'node to node' tau correction
+      EncapVecT tau(ncrse), rstr_and_crse(2 * ncrse);
+      // Attention: tau is getting filled with pointers to the crse's member
+      for (size_t m = 0; m < ncrse; m++) { tau[m] = crse.get_tau(m); }
+      for (size_t m = 0; m < ncrse; m++) { rstr_and_crse[m] = rstr_int[m]; }
+      for (size_t m = 0; m < ncrse; m++) { rstr_and_crse[ncrse + m] = crse_int[m]; }
+
+      if (fmat.rows() == 0) {
+        fmat.resize(ncrse, 2 * ncrse);
+        fmat.fill(0.0);
+
+        for (size_t m = 0; m < ncrse; m++) {
+          fmat(m, m) = 1.0;
+          fmat(m, ncrse + m) = -1.0;
+
+          // subtract 0-to-(m-1) FAS so resulting FAS is (m-1)-to-m FAS,
+          //  which will be required in the sweeper logic
+          for (size_t n = 0; n < m; n++) {
+            fmat(m, n) = -1.0;
+            fmat(m, ncrse + n) = 1.0;
+          }
+        }
+      }
+
+      tau[0]->mat_apply(tau, 1.0, fmat, rstr_and_crse, true);
+    }
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/encap/vector.hpp
+++ b/include/pfasst/encap/vector.hpp
@@ -1,21 +1,12 @@
-/*
- * Host based encapsulated base sweeper.
- */
-
 #ifndef _PFASST_VECTOR_HPP_
 #define _PFASST_VECTOR_HPP_
 
-#include <cstdlib>
-#include <ctime>
-#include <algorithm>
 #include <memory>
-#include <string>
 #include <vector>
-#include <cassert>
+using namespace std;
 
 #include "encapsulation.hpp"
 
-using namespace std;
 
 namespace pfasst
 {
@@ -34,136 +25,66 @@ namespace pfasst
     {
       public:
         //! @{
-        VectorEncapsulation(int size)
-          : vector<scalar>(size)
-        {
-          zero();
-        }
+        VectorEncapsulation(const size_t size);
 
         /**
          * @brief copy constuctor
          * @note delegated to sdt::vector<scalar>
          */
-        VectorEncapsulation(const VectorEncapsulation<scalar, time>& other)
-          : vector<scalar>(other)
-        {}
+        VectorEncapsulation(const VectorEncapsulation<scalar, time>& other);
+
         /**
          * @throws std::bad_cast
          *     if `other` can not be transformed into pfasst::encap::VectorEncapsulation via
          *     `dynamic_cast`
          */
-        VectorEncapsulation(const Encapsulation<time>& other)
-          : VectorEncapsulation(dynamic_cast<const VectorEncapsulation<scalar, time>>(other))
-        {}
+        VectorEncapsulation(const Encapsulation<time>& other);
 
         /**
          * @brief move constructor
          * @note delegated to std::vector<scalar>
          */
-        VectorEncapsulation(VectorEncapsulation<scalar, time>&& other)
-          : vector<scalar>(other)
-        {}
+        VectorEncapsulation(VectorEncapsulation<scalar, time>&& other);
+
         /**
          * @throws std::bad_cast
          *     if `other` can not be transformed into pfasst::encap::VectorEncapsulation via
          *     `dynamic_cast`
          */
-        VectorEncapsulation(Encapsulation<time>&& other)
-          : VectorEncapsulation(dynamic_cast<VectorEncapsulation<scalar, time>&&>(other))
-        {}
+        VectorEncapsulation(Encapsulation<time>&& other);
+
+        virtual ~VectorEncapsulation() = default;
         //! @}
 
         //! @{
-        void zero() override
-        {
-          this->assign(this->size(), scalar(0.0));
-        }
-
-        void copy(shared_ptr<const Encapsulation<time>> x) override
-        {
-          shared_ptr<const VectorEncapsulation<scalar, time>> x_cast = \
-            dynamic_pointer_cast<const VectorEncapsulation<scalar, time>>(x);
-          assert(x_cast);
-          this->copy(x_cast);
-        }
-
-        void copy(shared_ptr<const VectorEncapsulation<scalar, time>> x)
-        {
-          std::copy(x->cbegin(), x->cend(), this->begin());
-        }
+        virtual void zero() override;
+        virtual void copy(shared_ptr<const Encapsulation<time>> x) override;
+        virtual void copy(shared_ptr<const VectorEncapsulation<scalar, time>> x);
         //! @}
 
         //! @{
-        void saxpy(time a, shared_ptr<const Encapsulation<time>> x) override
-        {
-          shared_ptr<const VectorEncapsulation<scalar, time>> x_cast = \
-            dynamic_pointer_cast<const VectorEncapsulation<scalar, time>>(x);
-          assert(x_cast);
-
-          this->saxpy(a, x_cast);
-        }
-
-        void saxpy(time a, shared_ptr<const VectorEncapsulation<scalar, time>> x)
-        {
-          assert(this->size() == x->size());
-          for (size_t i = 0; i < this->size(); i++)
-          { this->data()[i] += a * x->data()[i]; }
-        }
+        virtual void saxpy(time a, shared_ptr<const Encapsulation<time>> x) override;
+        virtual void saxpy(time a, shared_ptr<const VectorEncapsulation<scalar, time>> x);
 
         /**
          * @note In case any of the elements of `dst` or `src` can not be transformed via
          *     `dynamic_cast` into pfasst::encap::VectorEncapsulation std::abort is called.
          */
-        void mat_apply(vector<shared_ptr<Encapsulation<time>>> dst, time a, Matrix<time> mat,
-                       vector<shared_ptr<Encapsulation<time>>> src, bool zero = true) override
-        {
-          size_t ndst = dst.size();
-          size_t nsrc = src.size();
-
-          vector<shared_ptr<VectorEncapsulation<scalar, time>>> dst_cast(ndst), src_cast(nsrc);
-          for (size_t n = 0; n < ndst; n++) {
-            dst_cast[n] = dynamic_pointer_cast<VectorEncapsulation<scalar, time>>(dst[n]);
-            assert(dst_cast[n]);
-          }
-          for (size_t m = 0; m < nsrc; m++) {
-            src_cast[m] = dynamic_pointer_cast<VectorEncapsulation<scalar, time>>(src[m]);
-            assert(src_cast[m]);
-          }
-
-          dst_cast[0]->mat_apply(dst_cast, a, mat, src_cast, zero);
-        }
-
-        void mat_apply(vector<shared_ptr<VectorEncapsulation<scalar, time>>> dst,
-                       time a, Matrix<time> mat,
-                       vector<shared_ptr<VectorEncapsulation<scalar, time>>> src, bool zero = true)
-        {
-          size_t ndst = dst.size();
-          size_t nsrc = src.size();
-
-          if (zero) { for (auto elem : dst) { elem->zero(); } }
-
-          size_t ndofs = dst[0]->size();
-          for (size_t i = 0; i < ndofs; i++) {
-            for (size_t n = 0; n < ndst; n++) {
-              assert(dst[n]->size() == ndofs);
-              for (size_t m = 0; m < nsrc; m++) {
-                assert(src[m]->size() == ndofs);
-                dst[n]->data()[i] += a * mat(n, m) * src[m]->data()[i];
-              }
-            }
-          }
-        }
+        virtual void mat_apply(vector<shared_ptr<Encapsulation<time>>> dst,
+                               time a, Matrix<time> mat,
+                               vector<shared_ptr<Encapsulation<time>>> src,
+                               bool zero = true) override;
+        virtual void mat_apply(vector<shared_ptr<VectorEncapsulation<scalar, time>>> dst,
+                               time a, Matrix<time> mat,
+                               vector<shared_ptr<VectorEncapsulation<scalar, time>>> src,
+                               bool zero = true);
 
         /**
          * maximum norm of contained elements.
          *
          * This uses std::max with custom comparison function.
          */
-        time norm0() const override
-        {
-          return std::abs(*std::max_element(this->cbegin(), this->cend(),
-                                            [](scalar a, scalar b) {return std::abs(a) < std::abs(b); } ));
-        }
+        virtual time norm0() const override;
         //! @}
 
     };
@@ -178,35 +99,23 @@ namespace pfasst
     class VectorFactory
       : public EncapFactory<time>
     {
-        int size;
+      protected:
+        size_t size;
+
       public:
-        int dofs() { return size; }
-        VectorFactory(const int size) : size(size) { }
-        shared_ptr<Encapsulation<time>> create(const EncapType)
-        {
-          return make_shared<VectorEncapsulation<scalar, time>>(size);
-        }
+        VectorFactory(const size_t size);
+        virtual shared_ptr<Encapsulation<time>> create(const EncapType) override;
+        size_t dofs() const;
     };
 
     template<typename scalar, typename time = time_precision>
-    VectorEncapsulation<scalar,time>& as_vector(shared_ptr<Encapsulation<time>> x)
-    {
-      typedef VectorEncapsulation<scalar,time> VectorT;
-      shared_ptr<VectorT> y = dynamic_pointer_cast<VectorT>(x);
-      assert(y);
-      return *y.get();
-    }
+    VectorEncapsulation<scalar,time>& as_vector(shared_ptr<Encapsulation<time>> x);
 
     template<typename scalar, typename time = time_precision>
-    const VectorEncapsulation<scalar,time>& as_vector(shared_ptr<const Encapsulation<time>> x)
-    {
-      typedef VectorEncapsulation<scalar,time> VectorT;
-      shared_ptr<const VectorT> y = dynamic_pointer_cast<const VectorT>(x);
-      assert(y);
-      return *y.get();
-    }
-
+    const VectorEncapsulation<scalar,time>& as_vector(shared_ptr<const Encapsulation<time>> x);
   }  // ::pfasst::encap
 }  // ::pfasst
+
+#include "vector_impl.hpp"
 
 #endif

--- a/include/pfasst/encap/vector_impl.hpp
+++ b/include/pfasst/encap/vector_impl.hpp
@@ -1,0 +1,171 @@
+#include "vector.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <vector>
+using namespace std;
+
+
+namespace pfasst
+{
+  namespace encap
+  {
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar, time>::VectorEncapsulation(const size_t size)
+      : vector<scalar>(size)
+    {
+      zero();
+    }
+
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar, time>::VectorEncapsulation(const VectorEncapsulation<scalar, time>& other)
+      : vector<scalar>(other)
+    {}
+
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar, time>::VectorEncapsulation(const Encapsulation<time>& other)
+      : VectorEncapsulation(dynamic_cast<const VectorEncapsulation<scalar, time>>(other))
+    {}
+
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar, time>::VectorEncapsulation(VectorEncapsulation<scalar, time>&& other)
+      : vector<scalar>(other)
+    {}
+
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar, time>::VectorEncapsulation(Encapsulation<time>&& other)
+      : VectorEncapsulation(dynamic_cast<VectorEncapsulation<scalar, time>&&>(other))
+    {}
+
+    template<typename scalar, typename time>
+    void VectorEncapsulation<scalar, time>::zero()
+    {
+      this->assign(this->size(), scalar(0.0));
+    }
+
+    template<typename scalar, typename time>
+    void VectorEncapsulation<scalar, time>::copy(shared_ptr<const Encapsulation<time>> x)
+    {
+      shared_ptr<const VectorEncapsulation<scalar, time>> x_cast = \
+        dynamic_pointer_cast<const VectorEncapsulation<scalar, time>>(x);
+      assert(x_cast);
+      this->copy(x_cast);
+    }
+
+    template<typename scalar, typename time>
+    void VectorEncapsulation<scalar, time>::copy(shared_ptr<const VectorEncapsulation<scalar, time>> x)
+    {
+      std::copy(x->cbegin(), x->cend(), this->begin());
+    }
+
+    template<typename scalar, typename time>
+    void VectorEncapsulation<scalar, time>::saxpy(time a, shared_ptr<const Encapsulation<time>> x)
+    {
+      shared_ptr<const VectorEncapsulation<scalar, time>> x_cast = \
+        dynamic_pointer_cast<const VectorEncapsulation<scalar, time>>(x);
+      assert(x_cast);
+
+      this->saxpy(a, x_cast);
+    }
+
+    template<typename scalar, typename time>
+    void VectorEncapsulation<scalar, time>::saxpy(time a, shared_ptr<const VectorEncapsulation<scalar, time>> x)
+    {
+      assert(this->size() == x->size());
+      for (size_t i = 0; i < this->size(); i++)
+      { this->data()[i] += a * x->data()[i]; }
+    }
+
+    template<typename scalar, typename time>
+    void
+    VectorEncapsulation<scalar, time>::mat_apply(vector<shared_ptr<Encapsulation<time>>> dst,
+                                                 time a, Matrix<time> mat,
+                                                 vector<shared_ptr<Encapsulation<time>>> src,
+                                                 bool zero)
+    {
+      size_t ndst = dst.size();
+      size_t nsrc = src.size();
+
+      vector<shared_ptr<VectorEncapsulation<scalar, time>>> dst_cast(ndst), src_cast(nsrc);
+      for (size_t n = 0; n < ndst; n++) {
+        dst_cast[n] = dynamic_pointer_cast<VectorEncapsulation<scalar, time>>(dst[n]);
+        assert(dst_cast[n]);
+      }
+      for (size_t m = 0; m < nsrc; m++) {
+        src_cast[m] = dynamic_pointer_cast<VectorEncapsulation<scalar, time>>(src[m]);
+        assert(src_cast[m]);
+      }
+
+      dst_cast[0]->mat_apply(dst_cast, a, mat, src_cast, zero);
+    }
+
+    template<typename scalar, typename time>
+    void
+    VectorEncapsulation<scalar, time>::mat_apply(vector<shared_ptr<VectorEncapsulation<scalar, time>>> dst,
+                                                 time a, Matrix<time> mat,
+                                                 vector<shared_ptr<VectorEncapsulation<scalar, time>>> src,
+                                                 bool zero)
+    {
+      size_t ndst = dst.size();
+      size_t nsrc = src.size();
+
+      if (zero) { for (auto elem : dst) { elem->zero(); } }
+
+      size_t ndofs = dst[0]->size();
+      for (size_t i = 0; i < ndofs; i++) {
+        for (size_t n = 0; n < ndst; n++) {
+          assert(dst[n]->size() == ndofs);
+          for (size_t m = 0; m < nsrc; m++) {
+            assert(src[m]->size() == ndofs);
+            dst[n]->data()[i] += a * mat(n, m) * src[m]->data()[i];
+          }
+        }
+      }
+    }
+
+    template<typename scalar, typename time>
+    time VectorEncapsulation<scalar, time>::norm0() const
+    {
+      return std::abs(*std::max_element(this->cbegin(), this->cend(),
+                                        [](scalar a, scalar b) {return std::abs(a) < std::abs(b); } ));
+    }
+
+
+    template<typename scalar, typename time>
+    VectorFactory<scalar, time>::VectorFactory(const size_t size)
+      : size(size)
+    {}
+
+    template<typename scalar, typename time>
+    size_t VectorFactory<scalar, time>::dofs() const
+    {
+      return size;
+    }
+
+    template<typename scalar, typename time>
+    shared_ptr<Encapsulation<time>> VectorFactory<scalar, time>::create(const EncapType)
+    {
+      return make_shared<VectorEncapsulation<scalar, time>>(this->dofs());
+    }
+
+
+    template<typename scalar, typename time>
+    VectorEncapsulation<scalar,time>& as_vector(shared_ptr<Encapsulation<time>> x)
+    {
+      typedef VectorEncapsulation<scalar,time> VectorT;
+      shared_ptr<VectorT> y = dynamic_pointer_cast<VectorT>(x);
+      assert(y);
+      return *y.get();
+    }
+
+    template<typename scalar, typename time>
+    const VectorEncapsulation<scalar,time>& as_vector(shared_ptr<const Encapsulation<time>> x)
+    {
+      typedef VectorEncapsulation<scalar,time> VectorT;
+      shared_ptr<const VectorT> y = dynamic_pointer_cast<const VectorT>(x);
+      assert(y);
+      return *y.get();
+    }
+
+  }  // ::pfasst::encap
+}  // ::pfasst

--- a/include/pfasst/interfaces.hpp
+++ b/include/pfasst/interfaces.hpp
@@ -5,8 +5,8 @@
 #ifndef _PFASST_INTERFACES_HPP_
 #define _PFASST_INTERFACES_HPP_
 
-#include <exception>
 #include <memory>
+#include <stdexcept>
 #include <string>
 using namespace std;
 
@@ -23,12 +23,20 @@ namespace pfasst
    * that may not be necessary for all others.
    */
   class NotImplementedYet
-    : public exception
+    : public runtime_error
   {
     protected:
       string msg;
+
     public:
-      NotImplementedYet(const string& msg);
+      /**
+       * @param[in] msg component or algorithm the throwing function is required for
+       */
+      explicit NotImplementedYet(const string& msg);
+
+      /**
+       * message string is prepended by the string `Not implemented/supported yet, required for: `
+       */
       virtual const char* what() const throw();
   };
 
@@ -39,12 +47,17 @@ namespace pfasst
    * Thrown when a PFASST routine is passed an invalid value.
    */
   class ValueError
-    : public exception
+    : public invalid_argument
   {
     protected:
       string msg;
+
     public:
-      ValueError(const string& msg);
+      explicit ValueError(const string& msg);
+
+      /**
+       * message string is prepended by the string `ValueError: `
+       */
       virtual const char* what() const throw();
   };
 
@@ -89,7 +102,7 @@ namespace pfasst
 
   /**
    * abstract SDC sweeper.
-   * @tparam time time precision
+   * @tparam time time precision;
    *     defaults to pfasst::time_precision
    */
   template<typename time = time_precision>
@@ -195,7 +208,7 @@ namespace pfasst
 
   /**
    * abstract time/space transfer (restrict/interpolate) class.
-   * @tparam time time precision
+   * @tparam time time precision;
    *     defaults to pfasst::time_precision
    */
   template<typename time = time_precision>

--- a/include/pfasst/interfaces.hpp
+++ b/include/pfasst/interfaces.hpp
@@ -33,10 +33,6 @@ namespace pfasst
        * @param[in] msg component or algorithm the throwing function is required for
        */
       explicit NotImplementedYet(const string& msg);
-
-      /**
-       * message string is prepended by the string `Not implemented/supported yet, required for: `
-       */
       virtual const char* what() const throw();
   };
 
@@ -54,10 +50,6 @@ namespace pfasst
 
     public:
       explicit ValueError(const string& msg);
-
-      /**
-       * message string is prepended by the string `ValueError: `
-       */
       virtual const char* what() const throw();
   };
 
@@ -121,9 +113,9 @@ namespace pfasst
       /**
        * set the sweepers controller.
        */
-      void set_controller(Controller<time>* ctrl);
+      virtual void set_controller(Controller<time>* ctrl);
 
-      Controller<time>* get_controller();
+      virtual Controller<time>* get_controller();
       //! @}
 
       //! @{

--- a/include/pfasst/interfaces_impl.hpp
+++ b/include/pfasst/interfaces_impl.hpp
@@ -14,6 +14,10 @@ namespace pfasst
     : runtime_error(msg)
   {}
 
+  /**
+   * @internal message string is prepended by the string
+   *   `Not implemented/supported yet, required for: `
+   */
   const char* NotImplementedYet::what() const throw()
   {
     return (string("Not implemented/supported yet, required for: ") + this->msg).c_str();
@@ -24,6 +28,9 @@ namespace pfasst
     : invalid_argument(msg)
   {}
 
+  /**
+   * @internal message string is prepended by the string `ValueError: `
+   */
   const char* ValueError::what() const throw()
   {
     return (string("ValueError: ") + this->msg).c_str();
@@ -50,6 +57,12 @@ namespace pfasst
     return !this->get_converged(this->comm->rank()-1);
   }
 
+  /**
+   * @internal Returning logic depends on current process' rank.
+   *   In case it is not the master process, both the converged state of this and the previous rank
+   *   are checked.
+   * @see `IStatus::get_converged()`
+   */
   bool IStatus::keep_iterating()
   {
     if (this->comm->rank() == 0) {
@@ -74,6 +87,11 @@ namespace pfasst
     this->controller = ctrl;
   }
 
+  /**
+   * @internal
+   * @note Asserts presense of a controller if `NDEBUG` is not defined.
+   * @endinternal
+   */
   template<typename time>
   Controller<time>* ISweeper<time>::get_controller()
   {
@@ -97,6 +115,9 @@ namespace pfasst
     return false;
   }
 
+  /**
+   * @throws NotImplementedYet This function is required by MLSDC and PFASST
+   */
   template<typename time>
   void ISweeper<time>::save(bool initial_only)
   {
@@ -104,6 +125,9 @@ namespace pfasst
     throw NotImplementedYet("mlsdc/pfasst");
   }
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
   void ISweeper<time>::spread()
   {
@@ -126,8 +150,11 @@ namespace pfasst
   void ISweeper<time>::post(ICommunicator* comm, int tag)
   {
     UNUSED(comm); UNUSED(tag);
-  };
+  }
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
   void ISweeper<time>::send(ICommunicator* comm, int tag, bool blocking)
   {
@@ -135,6 +162,9 @@ namespace pfasst
     throw NotImplementedYet("pfasst");
   }
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
   void ISweeper<time>::recv(ICommunicator* comm, int tag, bool blocking)
   {
@@ -142,6 +172,9 @@ namespace pfasst
     throw NotImplementedYet("pfasst");
   }
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
   void ISweeper<time>::broadcast(ICommunicator* comm)
   {
@@ -154,18 +187,25 @@ namespace pfasst
   ITransfer<time>::~ITransfer()
   {}
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
-  void ITransfer<time>::interpolate_initial(shared_ptr<ISweeper<time>> dst, shared_ptr<const ISweeper<time>> src)
+  void ITransfer<time>::interpolate_initial(shared_ptr<ISweeper<time>> dst,
+                                            shared_ptr<const ISweeper<time>> src)
   {
     UNUSED(dst); UNUSED(src);
     throw NotImplementedYet("pfasst");
   }
 
+  /**
+   * @throws NotImplementedYet This function is required by PFASST
+   */
   template<typename time>
-  void ITransfer<time>::restrict_initial(shared_ptr<ISweeper<time>> dst, shared_ptr<const ISweeper<time>> src)
+  void ITransfer<time>::restrict_initial(shared_ptr<ISweeper<time>> dst,
+                                         shared_ptr<const ISweeper<time>> src)
   {
     UNUSED(dst); UNUSED(src);
     throw NotImplementedYet("pfasst");
   }
-
 }  // ::pfasst

--- a/include/pfasst/interfaces_impl.hpp
+++ b/include/pfasst/interfaces_impl.hpp
@@ -1,0 +1,171 @@
+#include "interfaces.hpp"
+
+#include <cassert>
+#include <memory>
+#include <string>
+using namespace std;
+
+#include "globals.hpp"
+
+
+namespace pfasst
+{
+  NotImplementedYet::NotImplementedYet(const string& msg)
+    : msg(msg)
+  {}
+
+  const char* NotImplementedYet::what() const throw()
+  {
+    return (string("Not implemented/supported yet, required for: ") + this->msg).c_str();
+  }
+
+
+  ValueError::ValueError(const string& msg)
+    : msg(msg)
+  {}
+
+  const char* ValueError::what() const throw()
+  {
+    return (string("ValueError: ") + this->msg).c_str();
+  }
+
+
+  ICommunicator::~ICommunicator()
+  {}
+
+
+  IStatus::~IStatus()
+  {}
+
+  void IStatus::set_comm(ICommunicator* comm)
+  {
+    this->comm = comm;
+  }
+
+  bool IStatus::previous_is_iterating()
+  {
+    if (this->comm->rank() == 0) {
+      return false;
+    }
+    return !this->get_converged(this->comm->rank()-1);
+  }
+
+  bool IStatus::keep_iterating()
+  {
+    if (this->comm->rank() == 0) {
+      return !this->get_converged(0);
+    }
+    return !this->get_converged(this->comm->rank()) || !this->get_converged(this->comm->rank()-1);
+  }
+
+
+  template<typename time>
+  ISweeper<time>::ISweeper()
+    : controller(nullptr)
+  {}
+
+  template<typename time>
+  ISweeper<time>::~ISweeper()
+  {}
+
+  template<typename time>
+  void ISweeper<time>::set_controller(Controller<time>* ctrl)
+  {
+    this->controller = ctrl;
+  }
+
+  template<typename time>
+  Controller<time>* ISweeper<time>::get_controller()
+  {
+    assert(this->controller);
+    return this->controller;
+  }
+
+  template<typename time>
+  void ISweeper<time>::set_options()
+  {}
+
+  template<typename time>
+  void ISweeper<time>::setup(bool coarse)
+  {
+    UNUSED(coarse);
+  }
+
+  template<typename time>
+  bool ISweeper<time>::converged()
+  {
+    return false;
+  }
+
+  template<typename time>
+  void ISweeper<time>::save(bool initial_only)
+  {
+    UNUSED(initial_only);
+    throw NotImplementedYet("mlsdc/pfasst");
+  }
+
+  template<typename time>
+  void ISweeper<time>::spread()
+  {
+    throw NotImplementedYet("pfasst");
+  }
+
+  template<typename time>
+  void ISweeper<time>::post_sweep()
+  {}
+
+  template<typename time>
+  void ISweeper<time>::post_predict()
+  {}
+
+  template<typename time>
+  void ISweeper<time>::post_step()
+  {}
+
+  template<typename time>
+  void ISweeper<time>::post(ICommunicator* comm, int tag)
+  {
+    UNUSED(comm); UNUSED(tag);
+  };
+
+  template<typename time>
+  void ISweeper<time>::send(ICommunicator* comm, int tag, bool blocking)
+  {
+    UNUSED(comm); UNUSED(tag); UNUSED(blocking);
+    throw NotImplementedYet("pfasst");
+  }
+
+  template<typename time>
+  void ISweeper<time>::recv(ICommunicator* comm, int tag, bool blocking)
+  {
+    UNUSED(comm); UNUSED(tag); UNUSED(blocking);
+    throw NotImplementedYet("pfasst");
+  }
+
+  template<typename time>
+  void ISweeper<time>::broadcast(ICommunicator* comm)
+  {
+    UNUSED(comm);
+    throw NotImplementedYet("pfasst");
+  }
+
+
+  template<typename time>
+  ITransfer<time>::~ITransfer()
+  {}
+
+  template<typename time>
+  void ITransfer<time>::interpolate_initial(shared_ptr<ISweeper<time>> dst, shared_ptr<const ISweeper<time>> src)
+  {
+    UNUSED(dst); UNUSED(src);
+    throw NotImplementedYet("pfasst");
+  }
+
+  template<typename time>
+  void ITransfer<time>::restrict_initial(shared_ptr<ISweeper<time>> dst, shared_ptr<const ISweeper<time>> src)
+  {
+    UNUSED(dst); UNUSED(src);
+    throw NotImplementedYet("pfasst");
+  }
+
+}  // ::pfasst

--- a/include/pfasst/interfaces_impl.hpp
+++ b/include/pfasst/interfaces_impl.hpp
@@ -11,7 +11,7 @@ using namespace std;
 namespace pfasst
 {
   NotImplementedYet::NotImplementedYet(const string& msg)
-    : msg(msg)
+    : runtime_error(msg)
   {}
 
   const char* NotImplementedYet::what() const throw()
@@ -21,7 +21,7 @@ namespace pfasst
 
 
   ValueError::ValueError(const string& msg)
-    : msg(msg)
+    : invalid_argument(msg)
   {}
 
   const char* ValueError::what() const throw()

--- a/include/pfasst/mlsdc.hpp
+++ b/include/pfasst/mlsdc.hpp
@@ -1,22 +1,14 @@
-/*
- * Multi-level SDC controller.
- */
-
 #ifndef _PFASST_MLSDC_HPP_
 #define _PFASST_MLSDC_HPP_
 
-#include <algorithm>
-#include <iostream>
 #include <vector>
+using namespace std;
 
 #include "controller.hpp"
-#include "logging.hpp"
 
-using namespace std;
 
 namespace pfasst
 {
-
   /**
    * Multilevel SDC controller.
    */
@@ -33,21 +25,7 @@ namespace pfasst
       bool initial;   //<! whether we're sweeping from a new initial condition
       bool converged; //<! whether we've converged
 
-      void perform_sweeps(size_t level)
-      {
-        auto sweeper = this->get_level(level);
-        CLOG(INFO, "Controller") << "on level " << level + 1 << "/" << this->nlevels();
-        for (size_t s = 0; s < this->nsweeps[level]; s++) {
-          if (predict) {
-            sweeper->predict(initial & predict);
-            sweeper->post_predict();
-            predict = false;
-          } else {
-            sweeper->sweep();
-            sweeper->post_sweep();
-          }
-        }
-      }
+      virtual void perform_sweeps(size_t level);
 
     public:
       /**
@@ -56,56 +34,15 @@ namespace pfasst
        * This assumes that the user has set initial conditions on the finest level.
        * Currently uses a fixed number of iterations per step.
        */
-      void run()
-      {
-        for (; this->get_time() < this->get_end_time(); this->advance_time()) {
-          predict = true;
-          initial = true;
-          converged = false;
-
-          for (this->set_iteration(0);
-               this->get_iteration() < this->get_max_iterations() && !converged;
-               this->advance_iteration()) {
-            cycle_v(this->finest());
-            initial = false;
-          }
-
-          perform_sweeps(this->finest().level);
-
-          for (auto l = this->finest(); l >= this->coarsest(); --l) {
-            l.current()->post_step();
-          }
-
-          if (this->get_time() + this->get_time_step() < this->get_end_time()) {
-            this->get_finest()->advance();
-          }
-        }
-      }
+      virtual void setup() override;
+      virtual void set_nsweeps(vector<size_t> nsweeps);
+      virtual void run();
 
     private:
       /**
        * Cycle down: sweep on current (fine), restrict to coarse.
        */
-      LevelIter cycle_down(LevelIter l)
-      {
-        auto fine = l.current();
-        auto crse = l.coarse();
-        auto trns = l.transfer();
-
-        perform_sweeps(l.level);
-
-        if (l == this->finest() && fine->converged()) {
-          converged = true;
-          return l;
-        }
-
-        CVLOG(1, "Controller") << "Cycle down onto level " << l.level << "/" << this->nlevels();
-        trns->restrict(crse, fine, initial);
-        trns->fas(this->get_time_step(), crse, fine);
-        crse->save();
-
-        return l - 1;
-      }
+      virtual LevelIter cycle_down(LevelIter l);
 
       /**
        * Cycle up: interpolate coarse correction to fine, sweep on current (fine).
@@ -114,67 +51,20 @@ namespace pfasst
        * sweep.
        * In this case the only operation that is performed here is interpolation.
        */
-      LevelIter cycle_up(LevelIter l)
-      {
-        auto fine = l.current();
-        auto crse = l.coarse();
-        auto trns = l.transfer();
-
-        CVLOG(1, "Controller") << "Cycle up onto level " << l.level + 1 << "/" << this->nlevels();
-        trns->interpolate(fine, crse);
-
-        if (l < this->finest()) {
-          perform_sweeps(l.level);
-        }
-
-        return l + 1;
-      }
+      virtual LevelIter cycle_up(LevelIter l);
 
       /**
        * Cycle bottom: sweep on the current (coarsest) level.
        */
-      LevelIter cycle_bottom(LevelIter l)
-      {
-        perform_sweeps(l.level);
-        return l + 1;
-      }
+      virtual LevelIter cycle_bottom(LevelIter l);
 
       /**
        * Perform an MLSDC V-cycle.
        */
-      LevelIter cycle_v(LevelIter l)
-      {
-        if (l.level == 0) {
-          l = cycle_bottom(l);
-        } else {
-          l = cycle_down(l);
-          if (converged) {
-            return l;
-          }
-          l = cycle_v(l);
-          l = cycle_up(l);
-        }
-        return l;
-      }
-
-    public:
-      virtual void setup() override
-      {
-        nsweeps.resize(this->nlevels());
-        fill(nsweeps.begin(), nsweeps.end(), 1);
-        for (auto leviter = this->coarsest(); leviter <= this->finest(); ++leviter) {
-          leviter.current()->set_controller(this);
-          leviter.current()->setup(leviter != this->finest());
-        }
-      }
-
-      void set_nsweeps(vector<size_t> nsweeps)
-      {
-        this->nsweeps = nsweeps;
-      }
-
+      virtual LevelIter cycle_v(LevelIter l);
   };
-
 }  // ::pfasst
+
+#include "mlsdc_impl.hpp"
 
 #endif

--- a/include/pfasst/mlsdc_impl.hpp
+++ b/include/pfasst/mlsdc_impl.hpp
@@ -1,0 +1,133 @@
+#include "mlsdc.hpp"
+
+#include <algorithm>
+using namespace std;
+
+#include "logging.hpp"
+
+
+namespace pfasst
+{
+  template<typename time>
+  void MLSDC<time>::perform_sweeps(size_t level)
+  {
+    auto sweeper = this->get_level(level);
+    CLOG(INFO, "Controller") << "on level " << level + 1 << "/" << this->nlevels();
+    for (size_t s = 0; s < this->nsweeps[level]; s++) {
+      if (predict) {
+        sweeper->predict(initial & predict);
+        sweeper->post_predict();
+        predict = false;
+      } else {
+        sweeper->sweep();
+        sweeper->post_sweep();
+      }
+    }
+  }
+
+  template<typename time>
+  void MLSDC<time>::setup()
+  {
+    nsweeps.resize(this->nlevels());
+    fill(nsweeps.begin(), nsweeps.end(), 1);
+    for (auto leviter = this->coarsest(); leviter <= this->finest(); ++leviter) {
+      leviter.current()->set_controller(this);
+      leviter.current()->setup(leviter != this->finest());
+    }
+  }
+
+  template<typename time>
+  void MLSDC<time>::set_nsweeps(vector<size_t> nsweeps)
+  {
+    this->nsweeps = nsweeps;
+  }
+
+  template<typename time>
+  void MLSDC<time>::run()
+  {
+    for (; this->get_time() < this->get_end_time(); this->advance_time()) {
+      predict = true;
+      initial = true;
+      converged = false;
+
+      for (this->set_iteration(0);
+           this->get_iteration() < this->get_max_iterations() && !converged;
+           this->advance_iteration()) {
+        cycle_v(this->finest());
+        initial = false;
+      }
+
+      perform_sweeps(this->finest().level);
+
+      for (auto l = this->finest(); l >= this->coarsest(); --l) {
+        l.current()->post_step();
+      }
+
+      if (this->get_time() + this->get_time_step() < this->get_end_time()) {
+        this->get_finest()->advance();
+      }
+    }
+  }
+
+  template<typename time>
+  typename MLSDC<time>::LevelIter MLSDC<time>::cycle_down(typename MLSDC<time>::LevelIter l)
+  {
+    auto fine = l.current();
+    auto crse = l.coarse();
+    auto trns = l.transfer();
+
+    perform_sweeps(l.level);
+
+    if (l == this->finest() && fine->converged()) {
+      converged = true;
+      return l;
+    }
+
+    CVLOG(1, "Controller") << "Cycle down onto level " << l.level << "/" << this->nlevels();
+    trns->restrict(crse, fine, initial);
+    trns->fas(this->get_time_step(), crse, fine);
+    crse->save();
+
+    return l - 1;
+  }
+
+  template<typename time>
+  typename MLSDC<time>::LevelIter MLSDC<time>::cycle_up(typename MLSDC<time>::LevelIter l)
+  {
+    auto fine = l.current();
+    auto crse = l.coarse();
+    auto trns = l.transfer();
+
+    CVLOG(1, "Controller") << "Cycle up onto level " << l.level + 1 << "/" << this->nlevels();
+    trns->interpolate(fine, crse);
+
+    if (l < this->finest()) {
+      perform_sweeps(l.level);
+    }
+
+    return l + 1;
+  }
+
+  template<typename time>
+  typename MLSDC<time>::LevelIter MLSDC<time>::cycle_bottom(typename MLSDC<time>::LevelIter l)
+  {
+    perform_sweeps(l.level);
+    return l + 1;
+  }
+
+  template<typename time>
+  typename MLSDC<time>::LevelIter MLSDC<time>::cycle_v(typename MLSDC<time>::LevelIter l)
+  {
+    if (l.level == 0) {
+      l = cycle_bottom(l);
+    } else {
+      l = cycle_down(l);
+      if (converged) {
+        return l;
+      }
+      l = cycle_v(l);
+      l = cycle_up(l);
+    }
+    return l;
+  }
+}  // ::pfasst

--- a/include/pfasst/mpi_communicator.hpp
+++ b/include/pfasst/mpi_communicator.hpp
@@ -1,35 +1,29 @@
-/*
- * Interfaces for SDC/MLSDC/PFASST algorithms.
- */
-
 #ifndef _PFASST_MPI_COMMUNICATOR_HPP_
 #define _PFASST_MPI_COMMUNICATOR_HPP_
 
-#include <exception>
+#include <stdexcept>
 #include <vector>
+using namespace std;
 
 #include <mpi.h>
 
 #include "interfaces.hpp"
-#include "logging.hpp"
 
-using namespace std;
 
 namespace pfasst
 {
   namespace mpi
   {
-
     class MPIError
-      : public exception
+      : public runtime_error
     {
       public:
-        const char* what() const throw()
-        {
-          return "mpi error";
-        }
+        explicit MPIError(const string& msg="");
+        virtual const char* what() const throw();
     };
 
+
+    // forward declare for MPICommunicator
     class MPIStatus;
 
 
@@ -47,29 +41,14 @@ namespace pfasst
         //! @}
 
         //! @{
-        MPICommunicator()
-        {}
-
-        MPICommunicator(MPI_Comm comm)
-        {
-          set_comm(comm);
-        }
+        MPICommunicator();
+        MPICommunicator(MPI_Comm comm);
         //! @}
 
         //! @{
-        void set_comm(MPI_Comm comm)
-        {
-          this->comm = comm;
-          MPI_Comm_size(this->comm, &(this->_size));
-          MPI_Comm_rank(this->comm, &(this->_rank));
-
-          shared_ptr<MPIStatus> status = make_shared<MPIStatus>();
-          this->status = status;
-          this->status->set_comm(this);
-        }
-
-        int size() { return this->_size; }
-        int rank() { return this->_rank; }
+        virtual void set_comm(MPI_Comm comm);
+        virtual int size();
+        virtual int rank();
         //! @}
     };
 
@@ -77,85 +56,22 @@ namespace pfasst
     class MPIStatus
       : public IStatus
     {
+      protected:
         vector<bool> converged;
         MPICommunicator* mpi;
 
       public:
-
-        virtual void set_comm(ICommunicator* comm)
-        {
-          this->comm = comm;
-          this->converged.resize(comm->size());
-
-          this->mpi = dynamic_cast<MPICommunicator*>(comm); assert(this->mpi);
-        }
-
-        virtual void clear() override
-        {
-          std::fill(converged.begin(), converged.end(), false);
-        }
-
-        virtual void set_converged(bool converged) override
-        {
-          LOG(DEBUG) << "mpi rank " << this->comm->rank() << " set converged to " << converged;
-          this->converged.at(this->comm->rank()) = converged;
-        }
-
-        virtual bool get_converged(int rank) override
-        {
-          return this->converged.at(rank);
-        }
-
-        virtual void post()
-        {
-          // noop: send/recv for status info is blocking
-        }
-
-        virtual void send()
-        {
-          // don't send forward if: single processor run, or we're the last processor
-          if (mpi->size() == 1) { return; }
-          if (mpi->rank() == mpi->size() - 1) { return; }
-
-          int iconverged = converged.at(mpi->rank()) ? 1 : 0;
-
-          LOG(DEBUG) << "mpi rank " << this->comm->rank() << " status send " << iconverged;
-
-          int err = MPI_Send(&iconverged, sizeof(int), MPI_INT,
-                             (mpi->rank() + 1) % mpi->size(), 1, mpi->comm);
-
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-        }
-
-        virtual void recv()
-        {
-          // don't recv if: single processor run, or we're the first processor
-          if (mpi->size() == 1) { return; }
-          if (mpi->rank() == 0) { return; }
-
-          if (get_converged(mpi->rank()-1)) {
-            LOG(DEBUG) << "mpi rank " << this->comm->rank() << " skipping status recv";
-            return;
-          }
-
-          MPI_Status stat;
-          int iconverged;
-          int err = MPI_Recv(&iconverged, sizeof(iconverged), MPI_INT,
-                             (mpi->rank() - 1) % mpi->size(), 1, mpi->comm, &stat);
-
-          if (err != MPI_SUCCESS) {
-            throw MPIError();
-          }
-
-          converged.at(mpi->rank()-1) = iconverged == 1 ? true : false;
-
-          LOG(DEBUG) << "mpi rank " << this->comm->rank() << " status recv " << iconverged;
-        }
+        virtual void set_comm(ICommunicator* comm);
+        virtual void clear() override;
+        virtual void set_converged(bool converged) override;
+        virtual bool get_converged(int rank) override;
+        virtual void post();
+        virtual void send();
+        virtual void recv();
     };
-
   }  // ::pfasst::mpi
 }  // ::pfasst
+
+#include "mpi_communicator_impl.hpp"
 
 #endif

--- a/include/pfasst/mpi_communicator_impl.hpp
+++ b/include/pfasst/mpi_communicator_impl.hpp
@@ -1,0 +1,122 @@
+#include "mpi_communicator.hpp"
+
+#include "logging.hpp"
+
+
+namespace pfasst
+{
+  namespace mpi
+  {
+    MPIError::MPIError(const string& msg)
+      : runtime_error(msg)
+    {}
+
+    const char* MPIError::what() const throw()
+    {
+      return (string("mpi error: ") + string(runtime_error::what())).c_str();
+    }
+
+
+    MPICommunicator::MPICommunicator()
+    {}
+
+    MPICommunicator::MPICommunicator(MPI_Comm comm)
+    {
+      set_comm(comm);
+    }
+
+    void MPICommunicator::set_comm(MPI_Comm comm)
+    {
+      this->comm = comm;
+      MPI_Comm_size(this->comm, &(this->_size));
+      MPI_Comm_rank(this->comm, &(this->_rank));
+
+      shared_ptr<MPIStatus> status = make_shared<MPIStatus>();
+      this->status = status;
+      this->status->set_comm(this);
+    }
+
+    int MPICommunicator::size()
+    {
+      return this->_size;
+    }
+
+    int MPICommunicator::rank()
+    {
+      return this->_rank;
+    }
+
+
+    void MPIStatus::set_comm(ICommunicator* comm)
+    {
+      this->comm = comm;
+      this->converged.resize(comm->size());
+
+      this->mpi = dynamic_cast<MPICommunicator*>(comm); assert(this->mpi);
+    }
+
+    void MPIStatus::clear()
+    {
+      std::fill(converged.begin(), converged.end(), false);
+    }
+
+    void MPIStatus::set_converged(bool converged)
+    {
+      LOG(DEBUG) << "mpi rank " << this->comm->rank() << " set converged to " << converged;
+      this->converged.at(this->comm->rank()) = converged;
+    }
+
+    bool MPIStatus::get_converged(int rank)
+    {
+      return this->converged.at(rank);
+    }
+
+    void MPIStatus::post()
+    {
+      // noop: send/recv for status info is blocking
+    }
+
+    void MPIStatus::send()
+    {
+      // don't send forward if: single processor run, or we're the last processor
+      if (mpi->size() == 1) { return; }
+      if (mpi->rank() == mpi->size() - 1) { return; }
+
+      int iconverged = converged.at(mpi->rank()) ? 1 : 0;
+
+      LOG(DEBUG) << "mpi rank " << this->comm->rank() << " status send " << iconverged;
+
+      int err = MPI_Send(&iconverged, sizeof(int), MPI_INT,
+                         (mpi->rank() + 1) % mpi->size(), 1, mpi->comm);
+
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+    }
+
+    void MPIStatus::recv()
+    {
+      // don't recv if: single processor run, or we're the first processor
+      if (mpi->size() == 1) { return; }
+      if (mpi->rank() == 0) { return; }
+
+      if (get_converged(mpi->rank()-1)) {
+        LOG(DEBUG) << "mpi rank " << this->comm->rank() << " skipping status recv";
+        return;
+      }
+
+      MPI_Status stat;
+      int iconverged;
+      int err = MPI_Recv(&iconverged, sizeof(iconverged), MPI_INT,
+                         (mpi->rank() - 1) % mpi->size(), 1, mpi->comm, &stat);
+
+      if (err != MPI_SUCCESS) {
+        throw MPIError();
+      }
+
+      converged.at(mpi->rank()-1) = iconverged == 1 ? true : false;
+
+      LOG(DEBUG) << "mpi rank " << this->comm->rank() << " status recv " << iconverged;
+    }
+  }  // ::pfasst::mpi
+}  // ::pfasst

--- a/include/pfasst/pfasst_impl.hpp
+++ b/include/pfasst/pfasst_impl.hpp
@@ -1,0 +1,206 @@
+#include "pfasst.hpp"
+
+#include "logging.hpp"
+
+
+namespace pfasst
+{
+  template<typename time>
+  void PFASST<time>::perform_sweeps(size_t level)
+  {
+    auto sweeper = this->get_level(level);
+    for (size_t s = 0; s < this->nsweeps[level]; s++) {
+      if (predict) {
+        sweeper->predict(predict);
+        sweeper->post_predict();
+        predict = false;
+      } else {
+        sweeper->sweep();
+        sweeper->post_sweep();
+      }
+    }
+  }
+
+  template<typename time>
+  void PFASST<time>::run()
+  {
+    if (this->comm->size() == 1) {
+      pfasst::MLSDC<time>::run();
+      return;
+    }
+
+    int nblocks = int(this->get_end_time() / this->get_time_step()) / comm->size();
+
+    if (nblocks == 0) {
+      throw ValueError("invalid duration: there are more time processors than time steps");
+    }
+
+    for (int nblock = 0; nblock < nblocks; nblock++) {
+      this->set_step(nblock * comm->size() + comm->rank());
+
+      if (this->comm->size() == 1) {
+        predict = true;
+      } else {
+        predictor();
+      }
+
+      for (this->set_iteration(0);
+           this->get_iteration() < this->get_max_iterations() && this->comm->status->keep_iterating();
+           this->advance_iteration()) {
+
+        if (this->comm->status->previous_is_iterating()) {
+          post();
+        }
+        cycle_v(this->finest());
+      }
+
+      for (auto l = this->finest(); l >= this->coarsest(); --l) {
+        l.current()->post_step();
+      }
+
+      if (nblock < nblocks - 1) {
+        broadcast();
+      }
+
+      this->comm->status->clear();
+    }
+  }
+
+  template<typename time>
+  void PFASST<time>::set_comm(ICommunicator* comm)
+  {
+    this->comm = comm;
+  }
+
+  template<typename time>
+  typename PFASST<time>::LevelIter PFASST<time>::cycle_down(typename PFASST<time>::LevelIter l)
+  {
+    auto fine = l.current();
+    auto crse = l.coarse();
+    auto trns = l.transfer();
+
+    perform_sweeps(l.level);
+
+    if (l == this->finest() && fine->converged()) {
+      this->comm->status->set_converged(true);
+    }
+
+    fine->send(comm, tag(l), false);
+
+    trns->restrict(crse, fine, true);
+
+    trns->fas(this->get_time_step(), crse, fine);
+    crse->save();
+
+    return l - 1;
+  }
+
+  template<typename time>
+  typename PFASST<time>::LevelIter PFASST<time>::cycle_up(typename PFASST<time>::LevelIter l)
+  {
+    auto fine = l.current();
+    auto crse = l.coarse();
+    auto trns = l.transfer();
+
+    trns->interpolate(fine, crse, true);
+
+    if (this->comm->status->previous_is_iterating()) {
+      fine->recv(comm, tag(l), false);
+      trns->interpolate_initial(fine, crse);
+    }
+
+    if (l < this->finest()) {
+      perform_sweeps(l.level);
+    }
+
+    return l + 1;
+  }
+
+  template<typename time>
+  typename PFASST<time>::LevelIter PFASST<time>::cycle_bottom(typename PFASST<time>::LevelIter l)
+  {
+    auto crse = l.current();
+
+    if (this->comm->status->previous_is_iterating()) {
+      crse->recv(comm, tag(l), true);
+    }
+    this->comm->status->recv();
+    this->perform_sweeps(l.level);
+    crse->send(comm, tag(l), true);
+    this->comm->status->send();
+    return l + 1;
+  }
+
+  template<typename time>
+  typename PFASST<time>::LevelIter PFASST<time>::cycle_v(typename PFASST<time>::LevelIter l)
+  {
+    if (l.level == 0) {
+      l = cycle_bottom(l);
+    } else {
+      l = cycle_down(l);
+      l = cycle_v(l);
+      l = cycle_up(l);
+    }
+    return l;
+  }
+
+  template<typename time>
+  void PFASST<time>::predictor()
+  {
+    this->get_finest()->spread();
+
+    // restrict fine initial condition
+    for (auto l = this->finest() - 1; l >= this->coarsest(); --l) {
+      auto crse = l.current();
+      auto fine = l.fine();
+      auto trns = l.transfer();
+      trns->restrict_initial(crse, fine);
+      crse->spread();
+      crse->save();
+    }
+
+    // perform sweeps on the coarse level based on rank
+    predict = true;
+    auto crse = this->coarsest().current();
+    for (int nstep = 0; nstep < comm->rank() + 1; nstep++) {
+      // XXX: set iteration and step?
+      perform_sweeps(0);
+      if (nstep < comm->rank()) {
+        crse->advance();
+      }
+    }
+
+    // return to finest level, sweeping as we go
+    for (auto l = this->coarsest() + 1; l <= this->finest(); ++l) {
+      auto crse = l.coarse();
+      auto fine = l.current();
+      auto trns = l.transfer();
+
+      trns->interpolate(fine, crse, true);
+      if (l < this->finest()) {
+        perform_sweeps(l.level);
+      }
+    }
+  }
+
+  template<typename time>
+  void PFASST<time>::broadcast()
+  {
+    this->get_finest()->broadcast(comm);
+  }
+
+  template<typename time>
+  int PFASST<time>::tag(LevelIter l)
+  {
+    return l.level * 10000 + this->get_iteration() + 10;
+  }
+
+  template<typename time>
+  void PFASST<time>::post()
+  {
+    this->comm->status->post();
+    for (auto l = this->coarsest() + 1; l <= this->finest(); ++l) {
+      l.current()->post(comm, tag(l));
+    }
+  }
+}  // ::pfasst

--- a/include/pfasst/quadrature/clenshaw_curtis.hpp
+++ b/include/pfasst/quadrature/clenshaw_curtis.hpp
@@ -30,41 +30,24 @@ namespace pfasst
 
       public:
         //! @{
-        explicit ClenshawCurtis(const size_t num_nodes)
-          : IQuadrature<precision>(num_nodes)
-        {
-          if (this->num_nodes < 2) {
-            throw invalid_argument("Clenshaw-Curtis quadrature requires at least two quadrature nodes.");
-          }
-          this->compute_nodes();
-          this->compute_weights();
-        }
-
+        explicit ClenshawCurtis(const size_t num_nodes);
         ClenshawCurtis() = default;
-
         virtual ~ClenshawCurtis() = default;
         //! @}
 
         //! @{
-        virtual bool left_is_node() const { return LEFT_IS_NODE; }
-
-        virtual bool right_is_node() const { return RIGHT_IS_NODE; }
+        virtual bool left_is_node() const override;
+        virtual bool right_is_node() const override;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes()
-        {
-          this->nodes = vector<precision>(this->num_nodes, precision(0.0));
-          auto roots = Polynomial<precision>::legendre(this->num_nodes).roots();
-
-          for (size_t j = 0; j < this->num_nodes; j++) {
-            this->nodes[j] = 0.5 * (1.0 - cos(j * pi<precision>() / (this->num_nodes - 1)));
-          }
-        }
+        virtual void compute_nodes() override;
         //! @}
     };
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "clenshaw_curtis_impl.hpp"
 
 #endif  // _PFASST__QUADRATURE__CLENSHAW_CURTIS_HPP_

--- a/include/pfasst/quadrature/clenshaw_curtis_impl.hpp
+++ b/include/pfasst/quadrature/clenshaw_curtis_impl.hpp
@@ -1,0 +1,45 @@
+#include "clenshaw_curtis.hpp"
+
+#include <stdexcept>
+using namespace std;
+
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    ClenshawCurtis<precision>::ClenshawCurtis(const size_t num_nodes)
+      : IQuadrature<precision>(num_nodes)
+    {
+      if (this->num_nodes < 2) {
+        throw invalid_argument("Clenshaw-Curtis quadrature requires at least two quadrature nodes.");
+      }
+      this->compute_nodes();
+      this->compute_weights();
+    }
+
+    template<typename precision>
+    bool ClenshawCurtis<precision>::left_is_node() const
+    {
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool ClenshawCurtis<precision>::right_is_node() const
+    {
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void ClenshawCurtis<precision>::compute_nodes()
+    {
+      this->nodes = vector<precision>(this->num_nodes, precision(0.0));
+      auto roots = Polynomial<precision>::legendre(this->num_nodes).roots();
+
+      for (size_t j = 0; j < this->num_nodes; j++) {
+        this->nodes[j] = 0.5 * (1.0 - cos(j * pi<precision>() / (this->num_nodes - 1)));
+      }
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/quadrature/gauss_legendre.hpp
+++ b/include/pfasst/quadrature/gauss_legendre.hpp
@@ -1,14 +1,7 @@
 #ifndef _PFASST__QUADRATURE__GAUSS_LEGENDRE_HPP_
 #define _PFASST__QUADRATURE__GAUSS_LEGENDRE_HPP_
 
-#include <cassert>
-#include <vector>
-
-#include "../interfaces.hpp"
-#include "polynomial.hpp"
 #include "interface.hpp"
-
-using namespace std;
 
 
 namespace pfasst
@@ -27,38 +20,24 @@ namespace pfasst
 
       public:
         //! @{
-        explicit GaussLegendre(const size_t num_nodes)
-          : IQuadrature<precision>(num_nodes)
-        {
-          this->compute_nodes();
-          this->compute_weights();
-        }
-
+        explicit GaussLegendre(const size_t num_nodes);
         GaussLegendre() = default;
-
         virtual ~GaussLegendre() = default;
         //! @}
 
         //! @{
-        virtual bool left_is_node() const { return LEFT_IS_NODE; }
-
-        virtual bool right_is_node() const { return RIGHT_IS_NODE; }
+        virtual bool left_is_node() const override;
+        virtual bool right_is_node() const override;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes() override
-        {
-          this->nodes = vector<precision>(this->num_nodes, precision(0.0));
-          auto roots = Polynomial<precision>::legendre(this->num_nodes).roots();
-
-          for (size_t j = 0; j < this->num_nodes; j++) {
-            this->nodes[j] = 0.5 * (1.0 + roots[j]);
-          }
-        }
+        virtual void compute_nodes() override;
         //! @}
     };
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "gauss_legendre_impl.hpp"
 
 #endif  // _PFASST__QUADRATURE__GAUSS_LEGENDRE_HPP_

--- a/include/pfasst/quadrature/gauss_legendre_impl.hpp
+++ b/include/pfasst/quadrature/gauss_legendre_impl.hpp
@@ -1,0 +1,44 @@
+#include "gauss_legendre.hpp"
+
+#include <vector>
+using namespace std;
+
+#include "polynomial.hpp"
+
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    GaussLegendre<precision>::GaussLegendre(const size_t num_nodes)
+      : IQuadrature<precision>(num_nodes)
+    {
+      this->compute_nodes();
+      this->compute_weights();
+    }
+
+    template<typename precision>
+    bool GaussLegendre<precision>::left_is_node() const
+    {
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool GaussLegendre<precision>::right_is_node() const
+    {
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void GaussLegendre<precision>::compute_nodes()
+    {
+      this->nodes = vector<precision>(this->num_nodes, precision(0.0));
+      auto roots = Polynomial<precision>::legendre(this->num_nodes).roots();
+
+      for (size_t j = 0; j < this->num_nodes; j++) {
+        this->nodes[j] = 0.5 * (1.0 + roots[j]);
+      }
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/quadrature/gauss_lobatto.hpp
+++ b/include/pfasst/quadrature/gauss_lobatto.hpp
@@ -1,14 +1,7 @@
 #ifndef _PFASST__QUADRATURE__GAUSS_LOBATTO_HPP_
 #define _PFASST__QUADRATURE__GAUSS_LOBATTO_HPP_
 
-#include <cassert>
-#include <vector>
-
-#include "../interfaces.hpp"
-#include "polynomial.hpp"
 #include "interface.hpp"
-
-using namespace std;
 
 
 namespace pfasst
@@ -27,43 +20,24 @@ namespace pfasst
 
       public:
         //! @{
-        explicit GaussLobatto(const size_t num_nodes)
-          : IQuadrature<precision>(num_nodes)
-        {
-          if (this->num_nodes < 2) {
-            throw invalid_argument("Gauss-Lobatto quadrature requires at least two quadrature nodes.");
-          }
-          this->compute_nodes();
-          this->compute_weights();
-        }
-
+        explicit GaussLobatto(const size_t num_nodes);
         GaussLobatto() = default;
-
         virtual ~GaussLobatto() = default;
         //! @}
 
         //! @{
-        virtual bool left_is_node() const { return LEFT_IS_NODE; }
-
-        virtual bool right_is_node() const { return RIGHT_IS_NODE; }
+        virtual bool left_is_node() const override;
+        virtual bool right_is_node() const override;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes() override
-        {
-          this->nodes = vector<precision>(this->num_nodes, precision(0.0));
-          auto roots = Polynomial<precision>::legendre(this->num_nodes - 1).differentiate().roots();
-
-          for (size_t j = 0; j < this->num_nodes - 2; j++) {
-            this->nodes[j + 1] = 0.5 * (1.0 + roots[j]);
-          }
-          this->nodes.front() = 0.0;
-          this->nodes.back() = 1.0;
-        }
+        virtual void compute_nodes() override;
         //! @}
     };
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "gauss_lobatto_impl.hpp"
 
 #endif  // _PFASST__QUADRATURE__GAUSS_LOBATTO_HPP_

--- a/include/pfasst/quadrature/gauss_lobatto_impl.hpp
+++ b/include/pfasst/quadrature/gauss_lobatto_impl.hpp
@@ -1,0 +1,50 @@
+#include "gauss_lobatto.hpp"
+
+#include <stdexcept>
+#include <vector>
+using namespace std;
+
+#include "polynomial.hpp"
+
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    GaussLobatto<precision>::GaussLobatto(const size_t num_nodes)
+      : IQuadrature<precision>(num_nodes)
+    {
+      if (this->num_nodes < 2) {
+        throw invalid_argument("Gauss-Lobatto quadrature requires at least two quadrature nodes.");
+      }
+      this->compute_nodes();
+      this->compute_weights();
+    }
+
+    template<typename precision>
+    bool GaussLobatto<precision>::left_is_node() const
+    {
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool GaussLobatto<precision>::right_is_node() const
+    {
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void GaussLobatto<precision>::compute_nodes()
+    {
+      this->nodes = vector<precision>(this->num_nodes, precision(0.0));
+      auto roots = Polynomial<precision>::legendre(this->num_nodes - 1).differentiate().roots();
+
+      for (size_t j = 0; j < this->num_nodes - 2; j++) {
+        this->nodes[j + 1] = 0.5 * (1.0 + roots[j]);
+      }
+      this->nodes.front() = 0.0;
+      this->nodes.back() = 1.0;
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/quadrature/gauss_radau.hpp
+++ b/include/pfasst/quadrature/gauss_radau.hpp
@@ -1,14 +1,7 @@
 #ifndef _PFASST__QUADRATURE__GAUSS_RADAU_HPP_
 #define _PFASST__QUADRATURE__GAUSS_RADAU_HPP_
 
-#include <cassert>
-#include <vector>
-
-#include "../interfaces.hpp"
-#include "polynomial.hpp"
 #include "interface.hpp"
-
-using namespace std;
 
 
 namespace pfasst
@@ -27,47 +20,24 @@ namespace pfasst
 
       public:
         //! @{
-        explicit GaussRadau(const size_t num_nodes)
-          : IQuadrature<precision>(num_nodes)
-        {
-          if (this->num_nodes < 2) {
-            throw invalid_argument("Gauss-Radau quadrature requires at least two quadrature nodes.");
-          }
-          this->compute_nodes();
-          this->compute_weights();
-        }
-
+        explicit GaussRadau(const size_t num_nodes);
         GaussRadau() = default;
-
         virtual ~GaussRadau() = default;
         //! @}
 
         //! @{
-        virtual bool left_is_node() const { return LEFT_IS_NODE; }
-
-        virtual bool right_is_node() const { return RIGHT_IS_NODE; }
+        virtual bool left_is_node() const override;
+        virtual bool right_is_node() const override;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes() override
-        {
-          this->nodes = vector<precision>(this->num_nodes, precision(0.0));
-          auto l   = Polynomial<precision>::legendre(this->num_nodes);
-          auto lm1 = Polynomial<precision>::legendre(this->num_nodes - 1);
-
-          for (size_t i = 0; i < this->num_nodes; i++) {
-            l[i] += lm1[i];
-          }
-          auto roots = l.roots();
-          for (size_t j = 1; j < this->num_nodes; j++) {
-            this->nodes[j - 1] = 0.5 * (1.0 - roots[this->num_nodes - j]);
-          }
-          this->nodes.back() = 1.0;
-        }
+        virtual void compute_nodes() override;
         //! @}
     };
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "gauss_radau_impl.hpp"
 
 #endif  // _PFASST__QUADRATURE__GAUSS_RADAU_HPP_

--- a/include/pfasst/quadrature/gauss_radau_impl.hpp
+++ b/include/pfasst/quadrature/gauss_radau_impl.hpp
@@ -1,0 +1,54 @@
+#include "gauss_radau.hpp"
+
+#include <stdexcept>
+#include <vector>
+using namespace std;
+
+#include "polynomial.hpp"
+
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    GaussRadau<precision>::GaussRadau(const size_t num_nodes)
+      : IQuadrature<precision>(num_nodes)
+    {
+      if (this->num_nodes < 2) {
+        throw invalid_argument("Gauss-Radau quadrature requires at least two quadrature nodes.");
+      }
+      this->compute_nodes();
+      this->compute_weights();
+    }
+
+    template<typename precision>
+    bool GaussRadau<precision>::left_is_node() const
+    {
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool GaussRadau<precision>::right_is_node() const
+    {
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void GaussRadau<precision>::compute_nodes()
+    {
+      this->nodes = vector<precision>(this->num_nodes, precision(0.0));
+      auto l   = Polynomial<precision>::legendre(this->num_nodes);
+      auto lm1 = Polynomial<precision>::legendre(this->num_nodes - 1);
+
+      for (size_t i = 0; i < this->num_nodes; i++) {
+        l[i] += lm1[i];
+      }
+      auto roots = l.roots();
+      for (size_t j = 1; j < this->num_nodes; j++) {
+        this->nodes[j - 1] = 0.5 * (1.0 - roots[this->num_nodes - j]);
+      }
+      this->nodes.back() = 1.0;
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/quadrature/interface.hpp
+++ b/include/pfasst/quadrature/interface.hpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <vector>
+using namespace std;
 
 #include <Eigen/Dense>
 
@@ -16,7 +17,6 @@ using Matrix = Eigen::Matrix<scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowM
 template<typename scalar>
 using Index = typename Matrix<scalar>::Index;
 
-using namespace std;
 
 
 namespace pfasst
@@ -152,68 +152,32 @@ namespace pfasst
 
       public:
         //! @{
-        explicit IQuadrature(const size_t num_nodes)
-          : num_nodes(num_nodes)
-        {
-          if (this->num_nodes == 0) {
-            throw invalid_argument("Any quadrature requires at least one quadrature nodes.");
-          }
-        }
-
-        IQuadrature()
-          : num_nodes(0)
-        {}
-
+        explicit IQuadrature(const size_t num_nodes);
+        IQuadrature();
         virtual ~IQuadrature() = default;
         //! @}
 
         //! @{
-        virtual const Matrix<precision>& get_q_mat() const { return this->q_mat; }
-
-        virtual const Matrix<precision>& get_s_mat() const { return this->s_mat; }
-
-        virtual const Matrix<precision>& get_b_mat() const { return this->b_mat; }
-
-        virtual const vector<precision>& get_q_vec() const { return this->q_vec; }
-
-        virtual const vector<precision>& get_nodes() const { return this->nodes; }
-
-        virtual size_t get_num_nodes() const { return this->num_nodes; }
-
-        virtual bool left_is_node() const
-        {
-          throw NotImplementedYet("Quadrature");
-          return LEFT_IS_NODE;
-        }
-
-        virtual bool right_is_node() const
-        {
-          throw NotImplementedYet("Quadrature");
-          return RIGHT_IS_NODE;
-        }
+        virtual const Matrix<precision>& get_q_mat() const;
+        virtual const Matrix<precision>& get_s_mat() const;
+        virtual const Matrix<precision>& get_b_mat() const;
+        virtual const vector<precision>& get_q_vec() const;
+        virtual const vector<precision>& get_nodes() const;
+        virtual size_t get_num_nodes() const;
+        virtual bool left_is_node() const;
+        virtual bool right_is_node() const;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes()
-        {
-          throw NotImplementedYet("Implemented by derived classes.");
-        }
-
-        virtual void compute_weights()
-        {
-          this->q_mat = compute_q_matrix(this->nodes);
-          this->s_mat = compute_s_matrix(this->q_mat);
-          this->q_vec = compute_q_vec(this->nodes);
-          this->b_mat = Matrix<precision>::Zero(1, this->num_nodes);
-          for (size_t i = 0; i < this->num_nodes; i++){
-            this->b_mat(0,i) = this->q_vec[i];
-          }
-        }
+        virtual void compute_nodes();
+        virtual void compute_weights();
         //! @}
     };
 
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "interface_imp.hpp"
 
 #endif  // _PFASST__QUADRATURE__INTERFACE_HPP_

--- a/include/pfasst/quadrature/interface_imp.hpp
+++ b/include/pfasst/quadrature/interface_imp.hpp
@@ -1,0 +1,89 @@
+#include "interface.hpp"
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    IQuadrature<precision>::IQuadrature(const size_t num_nodes)
+      : num_nodes(num_nodes)
+    {
+      if (this->num_nodes == 0) {
+        throw invalid_argument("Any quadrature requires at least one quadrature nodes.");
+      }
+    }
+
+    template<typename precision>
+    IQuadrature<precision>::IQuadrature()
+      : num_nodes(0)
+    {}
+
+    template<typename precision>
+    const Matrix<precision>& IQuadrature<precision>::get_q_mat() const
+    {
+      return this->q_mat;
+    }
+
+    template<typename precision>
+    const Matrix<precision>& IQuadrature<precision>::get_s_mat() const
+    {
+      return this->s_mat;
+    }
+
+    template<typename precision>
+    const Matrix<precision>& IQuadrature<precision>::get_b_mat() const
+    {
+      return this->b_mat;
+    }
+
+    template<typename precision>
+    const vector<precision>& IQuadrature<precision>::get_q_vec() const
+    {
+      return this->q_vec;
+    }
+
+    template<typename precision>
+    const vector<precision>& IQuadrature<precision>::get_nodes() const
+    {
+      return this->nodes;
+    }
+
+    template<typename precision>
+    size_t IQuadrature<precision>::get_num_nodes() const
+    {
+      return this->num_nodes;
+    }
+
+    template<typename precision>
+    bool IQuadrature<precision>::left_is_node() const
+    {
+      throw NotImplementedYet("Quadrature");
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool IQuadrature<precision>::right_is_node() const
+    {
+      throw NotImplementedYet("Quadrature");
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void IQuadrature<precision>::compute_nodes()
+    {
+      throw NotImplementedYet("Implemented by derived classes.");
+    }
+
+    template<typename precision>
+    void IQuadrature<precision>::compute_weights()
+    {
+      this->q_mat = compute_q_matrix(this->nodes);
+      this->s_mat = compute_s_matrix(this->q_mat);
+      this->q_vec = compute_q_vec(this->nodes);
+      this->b_mat = Matrix<precision>::Zero(1, this->num_nodes);
+      for (size_t i = 0; i < this->num_nodes; i++){
+        this->b_mat(0,i) = this->q_vec[i];
+      }
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/quadrature/polynomial.hpp
+++ b/include/pfasst/quadrature/polynomial.hpp
@@ -1,14 +1,7 @@
 #ifndef _PFASST__POLYNOMIAL_HPP_
 #define _PFASST__POLYNOMIAL_HPP_
 
-#include <algorithm>
-#include <cassert>
-#include <cmath>
-#include <complex>
-#include <limits>
 #include <vector>
-
-
 using namespace std;
 
 
@@ -17,40 +10,16 @@ namespace pfasst
   template<typename CoeffT>
   class Polynomial
   {
+    protected:
       vector<CoeffT> c;
 
     public:
-      Polynomial(size_t n)
-        : c(n, CoeffT(0.0))
-      {}
+      Polynomial(size_t n);
 
-      size_t order() const
-      {
-        return c.size() - 1;
-      }
-
-      CoeffT& operator[](const size_t i)
-      {
-        return c.at(i);
-      }
-
-      Polynomial<CoeffT> differentiate() const
-      {
-        Polynomial<CoeffT> p(c.size() - 1);
-        for (size_t j = 1; j < c.size(); j++) {
-          p[j - 1] = j * c[j];
-        }
-        return p;
-      }
-
-      Polynomial<CoeffT> integrate() const
-      {
-        Polynomial<CoeffT> p(c.size() + 1);
-        for (size_t j = 0; j < c.size(); j++) {
-          p[j + 1] = c[j] / (j + 1);
-        }
-        return p;
-      }
+      size_t order() const;
+      CoeffT& operator[](const size_t i);
+      Polynomial<CoeffT> differentiate() const;
+      Polynomial<CoeffT> integrate() const;
 
       template<typename xtype>
       xtype evaluate(const xtype x) const
@@ -63,93 +32,12 @@ namespace pfasst
         return v;
       }
 
-      Polynomial<CoeffT> normalize() const
-      {
-        Polynomial<CoeffT> p(c.size());
-        for (size_t j = 0; j < c.size(); j++) {
-          p[j] = c[j] / c.back();
-        }
-        return p;
-      }
-
-      vector<CoeffT> roots() const
-      {
-        assert(c.size() >= 1);
-        size_t n = c.size() - 1;
-
-        // initial guess
-        Polynomial<complex<CoeffT>> z0(n), z1(n);
-        for (size_t j = 0; j < n; j++) {
-          z0[j] = pow(complex<double>(0.4, 0.9), j);
-          z1[j] = z0[j];
-        }
-
-        // durand-kerner-weierstrass iterations
-        Polynomial<CoeffT> p = normalize();
-        for (size_t k = 0; k < 100; k++) {
-          complex<CoeffT> num, den;
-          for (size_t i = 0; i < n; i++) {
-            num = p.evaluate(z0[i]);
-            den = 1.0;
-            for (size_t j = 0; j < n; j++) {
-              if (j == i) { continue; }
-              den = den * (z0[i] - z0[j]);
-            }
-            z0[i] = z0[i] - num / den;
-          }
-
-          // converged?
-          CoeffT acc = 0.0;
-          for (size_t j = 0; j < n; j++) { acc += abs(z0[j] - z1[j]); }
-          if (acc < 2 * numeric_limits<CoeffT>::epsilon()) { break; }
-
-          z1 = z0;
-        }
-
-        vector<CoeffT> roots(n);
-        for (size_t j = 0; j < n; j++) {
-          roots[j] = (abs(z0[j]) < 4 * numeric_limits<CoeffT>::epsilon()) ? 0.0 : real(z0[j]);
-        }
-
-        sort(roots.begin(), roots.end());
-        return roots;
-      }
-
-      static Polynomial<CoeffT> legendre(const size_t order)
-      {
-        if (order == 0) {
-          Polynomial<CoeffT> p(1);
-          p[0] = 1.0;
-          return p;
-        }
-
-        if (order == 1) {
-          Polynomial<CoeffT> p(2);
-          p[0] = 0.0;
-          p[1] = 1.0;
-          return p;
-        }
-
-        Polynomial<CoeffT> p0(order + 1), p1(order + 1), p2(order + 1);
-        p0[0] = 1.0; p1[1] = 1.0;
-
-        // (n + 1) P_{n+1} = (2n + 1) x P_{n} - n P_{n-1}
-        for (size_t m = 1; m < order; m++) {
-          for (size_t j = 1; j < order + 1; j++) {
-            p2[j] = ((2 * m + 1) * p1[j - 1] - m * p0[j]) / (m + 1);
-          }
-          p2[0] = - int(m) * p0[0] / (m + 1);
-
-          for (size_t j = 0; j < order + 1; j++) {
-            p0[j] = p1[j];
-            p1[j] = p2[j];
-          }
-        }
-
-        return p2;
-      }
+      Polynomial<CoeffT> normalize() const;
+      vector<CoeffT> roots() const;
+      static Polynomial<CoeffT> legendre(const size_t order);
   };
-
 }  // ::pfasst
+
+#include "polynomial_impl.hpp"
 
 #endif  // _PFASST__POLYNOMIAL_HPP_

--- a/include/pfasst/quadrature/polynomial_impl.hpp
+++ b/include/pfasst/quadrature/polynomial_impl.hpp
@@ -1,0 +1,138 @@
+#include "polynomial.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <limits>
+using namespace std;
+
+
+namespace pfasst
+{
+  template<typename CoeffT>
+  Polynomial<CoeffT>::Polynomial(size_t n)
+    : c(n, CoeffT(0.0))
+  {}
+
+  template<typename CoeffT>
+  size_t Polynomial<CoeffT>::order() const
+  {
+    return c.size() - 1;
+  }
+
+  template<typename CoeffT>
+  CoeffT& Polynomial<CoeffT>::operator[](const size_t i)
+  {
+    return c.at(i);
+  }
+
+  template<typename CoeffT>
+  Polynomial<CoeffT> Polynomial<CoeffT>::differentiate() const
+  {
+    Polynomial<CoeffT> p(c.size() - 1);
+    for (size_t j = 1; j < c.size(); j++) {
+      p[j - 1] = j * c[j];
+    }
+    return p;
+  }
+
+  template<typename CoeffT>
+  Polynomial<CoeffT> Polynomial<CoeffT>::integrate() const
+  {
+    Polynomial<CoeffT> p(c.size() + 1);
+    for (size_t j = 0; j < c.size(); j++) {
+      p[j + 1] = c[j] / (j + 1);
+    }
+    return p;
+  }
+
+  template<typename CoeffT>
+  Polynomial<CoeffT> Polynomial<CoeffT>::normalize() const
+  {
+    Polynomial<CoeffT> p(c.size());
+    for (size_t j = 0; j < c.size(); j++) {
+      p[j] = c[j] / c.back();
+    }
+    return p;
+  }
+
+  template<typename CoeffT>
+  vector<CoeffT> Polynomial<CoeffT>::roots() const
+  {
+    assert(c.size() >= 1);
+    size_t n = c.size() - 1;
+
+    // initial guess
+    Polynomial<complex<CoeffT>> z0(n), z1(n);
+    for (size_t j = 0; j < n; j++) {
+      z0[j] = pow(complex<double>(0.4, 0.9), j);
+      z1[j] = z0[j];
+    }
+
+    // durand-kerner-weierstrass iterations
+    Polynomial<CoeffT> p = normalize();
+    for (size_t k = 0; k < 100; k++) {
+      complex<CoeffT> num, den;
+      for (size_t i = 0; i < n; i++) {
+        num = p.evaluate(z0[i]);
+        den = 1.0;
+        for (size_t j = 0; j < n; j++) {
+          if (j == i) { continue; }
+          den = den * (z0[i] - z0[j]);
+        }
+        z0[i] = z0[i] - num / den;
+      }
+
+      // converged?
+      CoeffT acc = 0.0;
+      for (size_t j = 0; j < n; j++) { acc += abs(z0[j] - z1[j]); }
+      if (acc < 2 * numeric_limits<CoeffT>::epsilon()) { break; }
+
+      z1 = z0;
+    }
+
+    vector<CoeffT> roots(n);
+    for (size_t j = 0; j < n; j++) {
+      roots[j] = (abs(z0[j]) < 4 * numeric_limits<CoeffT>::epsilon()) ? 0.0 : real(z0[j]);
+    }
+
+    sort(roots.begin(), roots.end());
+    return roots;
+  }
+
+  template<typename CoeffT>
+  Polynomial<CoeffT> Polynomial<CoeffT>::legendre(const size_t order)
+  {
+    if (order == 0) {
+      Polynomial<CoeffT> p(1);
+      p[0] = 1.0;
+      return p;
+    }
+
+    if (order == 1) {
+      Polynomial<CoeffT> p(2);
+      p[0] = 0.0;
+      p[1] = 1.0;
+      return p;
+    }
+
+    Polynomial<CoeffT> p0(order + 1), p1(order + 1), p2(order + 1);
+    p0[0] = 1.0; p1[1] = 1.0;
+
+    // (n + 1) P_{n+1} = (2n + 1) x P_{n} - n P_{n-1}
+    for (size_t m = 1; m < order; m++) {
+      for (size_t j = 1; j < order + 1; j++) {
+        p2[j] = ((2 * m + 1) * p1[j - 1] - m * p0[j]) / (m + 1);
+      }
+      p2[0] = - int(m) * p0[0] / (m + 1);
+
+      for (size_t j = 0; j < order + 1; j++) {
+        p0[j] = p1[j];
+        p1[j] = p2[j];
+      }
+    }
+
+    return p2;
+  }
+}  // ::pfasst

--- a/include/pfasst/quadrature/uniform.hpp
+++ b/include/pfasst/quadrature/uniform.hpp
@@ -1,13 +1,7 @@
 #ifndef _PFASST__QUADRATURE__UNIFORM_HPP_
 #define _PFASST__QUADRATURE__UNIFORM_HPP_
 
-#include <cassert>
-#include <vector>
-
-#include "../interfaces.hpp"
 #include "interface.hpp"
-
-using namespace std;
 
 
 namespace pfasst
@@ -26,39 +20,24 @@ namespace pfasst
 
       public:
         //! @{
-        explicit Uniform(const size_t num_nodes)
-          : IQuadrature<precision>(num_nodes)
-        {
-          if (this->num_nodes < 2) {
-            throw invalid_argument("Uniform quadrature requires at least two quadrature nodes.");
-          }
-          this->compute_nodes();
-          this->compute_weights();
-        }
-
+        explicit Uniform(const size_t num_nodes);
         Uniform() = default;
-
         virtual ~Uniform() = default;
         //! @}
 
         //! @{
-        virtual bool left_is_node() const { return LEFT_IS_NODE; }
-
-        virtual bool right_is_node() const { return RIGHT_IS_NODE; }
+        virtual bool left_is_node() const override;
+        virtual bool right_is_node() const override;
         //! @}
 
       protected:
         //! @{
-        virtual void compute_nodes()
-        {
-          this->nodes = vector<precision>(this->num_nodes, precision(0.0));
-          for (size_t j = 0; j < this->num_nodes; j++) {
-            this->nodes[j] = precision(j) / (this->num_nodes - 1);
-          }
-        }
+        virtual void compute_nodes() override;
         //! @}
     };
   }  // ::pfasst::quadrature
 }  // ::pfasst
+
+#include "uniform_impl.hpp"
 
 #endif  // _PFASST__QUADRATURE__UNIFORM_HPP_

--- a/include/pfasst/quadrature/uniform_impl.hpp
+++ b/include/pfasst/quadrature/uniform_impl.hpp
@@ -1,0 +1,44 @@
+#include "uniform.hpp"
+
+#include <stdexcept>
+#include <vector>
+using namespace std;
+
+
+namespace pfasst
+{
+  namespace quadrature
+  {
+    template<typename precision>
+    Uniform<precision>::Uniform(const size_t num_nodes)
+      : IQuadrature<precision>(num_nodes)
+    {
+      if (this->num_nodes < 2) {
+        throw invalid_argument("Uniform quadrature requires at least two quadrature nodes.");
+      }
+      this->compute_nodes();
+      this->compute_weights();
+    }
+
+    template<typename precision>
+    bool Uniform<precision>::left_is_node() const
+    {
+      return LEFT_IS_NODE;
+    }
+
+    template<typename precision>
+    bool Uniform<precision>::right_is_node() const
+    {
+      return RIGHT_IS_NODE;
+    }
+
+    template<typename precision>
+    void Uniform<precision>::compute_nodes()
+    {
+      this->nodes = vector<precision>(this->num_nodes, precision(0.0));
+      for (size_t j = 0; j < this->num_nodes; j++) {
+        this->nodes[j] = precision(j) / (this->num_nodes - 1);
+      }
+    }
+  }  // ::pfasst::quadrature
+}  // ::pfasst

--- a/include/pfasst/sdc.hpp
+++ b/include/pfasst/sdc.hpp
@@ -1,49 +1,23 @@
-/*
- * Vanilla SDC controller.
- */
-
 #ifndef _PFASST_SDC_HPP_
 #define _PFASST_SDC_HPP_
 
-#include <iostream>
-using namespace std;
-
 #include "controller.hpp"
-#include "config.hpp"
+
 
 namespace pfasst
 {
+  /**
+   * Vanilla SDC controller.
+   */
   template<typename time = time_precision>
   class SDC
     : public Controller<time>
   {
     public:
-      void run()
-      {
-        auto sweeper = this->get_level(0);
-
-        for (; this->get_time() < this->get_end_time(); this->advance_time()) {
-          bool initial = this->get_step() == 0;
-          for (this->set_iteration(0);
-               this->get_iteration() < this->get_max_iterations();
-               this->advance_iteration()) {
-            bool predict = this->get_iteration() == 0;
-            if (predict) {
-              sweeper->predict(initial);
-              sweeper->post_predict();
-            } else {
-              sweeper->sweep();
-              sweeper->post_sweep();
-            }
-            if (sweeper->converged()) {
-              break;
-            }
-          }
-          sweeper->post_step();
-          sweeper->advance();
-        }
-      }
+      virtual void run();
   };
 }  // ::pfasst
+
+#include "sdc_impl.hpp"
 
 #endif

--- a/include/pfasst/sdc_impl.hpp
+++ b/include/pfasst/sdc_impl.hpp
@@ -1,0 +1,32 @@
+#include "sdc.hpp"
+
+
+namespace pfasst
+{
+  template<typename time>
+  void SDC<time>::run()
+  {
+    auto sweeper = this->get_level(0);
+
+    for (; this->get_time() < this->get_end_time(); this->advance_time()) {
+      bool initial = this->get_step() == 0;
+      for (this->set_iteration(0);
+           this->get_iteration() < this->get_max_iterations();
+           this->advance_iteration()) {
+        bool predict = this->get_iteration() == 0;
+        if (predict) {
+          sweeper->predict(initial);
+          sweeper->post_predict();
+        } else {
+          sweeper->sweep();
+          sweeper->post_sweep();
+        }
+        if (sweeper->converged()) {
+          break;
+        }
+      }
+      sweeper->post_step();
+      sweeper->advance();
+    }
+  }
+}  // ::pfasst


### PR DESCRIPTION
This should fix #84.

I'm thinking about moving the implementation files into a separate directory tree (e.g. `src`) beside `include`. What do you think of that?

I'd also like to move the controllers (SDC, MLSDC, PFASST) into their own subfolder.