### PR TITLE
cmake: adding version number as const-string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,20 +151,22 @@ message(STATUS "Configuring 3rd party libraries")
 #  - FFTW_LIBRARIES (if pfasst_BUILD_EXAMPLES)
 add_subdirectory(3rdparty)
 
+message(STATUS "********************************************************************************")
+message(STATUS "Configuring sources")
+update_site_config()
+
+add_custom_target(set_version ALL
+    COMMAND ${pfasst_SOURCE_DIR}/tools/get_pfasst_version.sh
+    WORKING_DIRECTORY ${pfasst_SOURCE_DIR}
+    COMMENT "Updating PFASST++ version number"
+    USES_TERMINAL
+)
+set(pfasst_DEPENDEND_TARGETS set_version ${pfasst_DEPENDEND_TARGETS})
+
 list(LENGTH pfasst_DEPENDEND_LIBS pfasst_NUM_DEPENDEND_LIBS)
 list(LENGTH pfasst_DEPENDEND_TARGETS pfasst_NUM_DEPENDEND_TARGETS)
 list(LENGTH pfasst_TESTS_DEPENDEND_TARGETS pfasst_TESTS_NUM_DEPENDEND_TARGETS)
 
-message(STATUS "********************************************************************************")
-message(STATUS "Configuring sources")
-set(WARNING_COMMENT "/*\n * DO NOT ALTER THIS FILE\n *\n * It will get rewritten on CMake's next run\n *\n */")
-if(pfasst_RANDOM_SEED)
-    add_definitions(-DPFASST_DEFAULT_RANDOM_SEED)
-endif()
-configure_file(
-    "${pfasst_SOURCE_DIR}/cmake/site_config.hpp.in"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/pfasst/site_config.hpp"
-)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/cmake/site_config.hpp.in
+++ b/cmake/site_config.hpp.in
@@ -7,4 +7,12 @@
   #define PFASST_RANDOM_SEED @pfasst_RANDOM_SEED@
 #endif
 
+#include <string>
+using namespace std;
+
+namespace pfasst
+{
+  static constexpr const char* VERSION = "pfasst_VERSION";
+}  // ::pfasst
+
 #endif  // _PFASST__SITE_CONFIG_HPP

--- a/cmake/utility_functions.cmake
+++ b/cmake/utility_functions.cmake
@@ -27,3 +27,14 @@ macro(msg_not_installed dependency_name)
     message("!  ${dependency_name} manually to your project.")
     message("!!!!")
 endmacro(msg_not_installed)
+
+macro(update_site_config)
+    set(WARNING_COMMENT "/*\n * DO NOT ALTER THIS FILE\n *\n * It will get rewritten on CMake's next run\n */")
+    if(pfasst_RANDOM_SEED)
+        add_definitions(-DPFASST_DEFAULT_RANDOM_SEED)
+    endif()
+    configure_file(
+        "${pfasst_SOURCE_DIR}/cmake/site_config.hpp.in"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/pfasst/site_config.hpp"
+    )
+endmacro(update_site_config)

--- a/include/pfasst/logging.hpp
+++ b/include/pfasst/logging.hpp
@@ -390,6 +390,7 @@ namespace pfasst
       set_logging_flags();
       load_default_config();
       pfasst::log::stack_position = 0;
+      CLOG(INFO, "default") << "PFASST++ version " << pfasst::VERSION;
     }
   }  // ::pfasst::log
 }  // ::pfasst

--- a/tools/get_pfasst_version.sh
+++ b/tools/get_pfasst_version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PFASST_DIR="${SCRIPTPATH}/.."
+GIT="`which git`"
+
+cd "${PFASST_DIR}"
+CONFIG_HPP="include/pfasst/site_config.hpp"
+
+if [[ -s "${CONFIG_HPP}" ]]; then
+  VERSION=`"${GIT}" describe` || "unknown"
+  sed -i "s/pfasst_VERSION/${VERSION}/g" "${CONFIG_HPP}"
+  echo "PFASST++ version set to ${VERSION}"
+  exit 0;
+else
+  echo "include/pfasst/site_config.hpp not found"
+  exit 1;
+fi


### PR DESCRIPTION
The version number is determined by running `git describe` at the very
first target to build by `make`. In case it fails (e.g. git not
available), it will be set to "unknown".
Withing PFASST++ it is defined as

    static constexpr const char* pfasst::VERSION