### PR TITLE
Fix PFASST on one processor.

### DIFF
--- a/include/pfasst/controller/mlsdc.hpp
+++ b/include/pfasst/controller/mlsdc.hpp
@@ -39,7 +39,7 @@ namespace pfasst
        * @param[in] level level index to perform pre-configured number of sweeps
        * @see set_nsweeps() for pre-configuring number of sweeps
        */
-      virtual void perform_sweeps(size_t level);
+      void perform_sweeps(size_t level);
 
     public:
       //! @copydoc Controller::setup()
@@ -69,7 +69,7 @@ namespace pfasst
        * @returns level iterator to current level if it has converged after the sweep; otherwise a
        *   level iterator to the next coarser level
        */
-      virtual LevelIter cycle_down(LevelIter level_iter);
+      LevelIter cycle_down(LevelIter level_iter);
 
       /**
        * Interpolate coarse correction to fine, sweep on current (fine).
@@ -77,7 +77,7 @@ namespace pfasst
        * @param[in] level_iter level iterator pointing to the finer level
        * @returns level iterator pointing to the coarser level
        */
-      virtual LevelIter cycle_up(LevelIter level_iter);
+      LevelIter cycle_up(LevelIter level_iter);
 
       /**
        * Sweep on the current (coarsest) level.
@@ -87,17 +87,17 @@ namespace pfasst
        *
        * @pre It is assumed that @p level_iter currently points to the coarsest level.
        */
-      virtual LevelIter cycle_bottom(LevelIter level_iter);
+      LevelIter cycle_bottom(LevelIter level_iter);
 
       /**
        * Perform an MLSDC V-cycle.
        *
        * @param[in] level_iter level iterator pointing to a fine level
-       * @returns level iterator pointing to either the coarsest level if @p level_iter is the 
+       * @returns level iterator pointing to either the coarsest level if @p level_iter is the
        *   coarsest level or the same level as @p level_iter if a sweep on that level results in
        *   convergence or all sweeps on all coarser levels did not let to convergence
        */
-      virtual LevelIter cycle_v(LevelIter level_iter);
+      LevelIter cycle_v(LevelIter level_iter);
   };
 }  // ::pfasst
 

--- a/include/pfasst/controller/pfasst.hpp
+++ b/include/pfasst/controller/pfasst.hpp
@@ -24,10 +24,7 @@ namespace pfasst
       ICommunicator* comm;  //!< communicator to use
       bool predict;         //!< whether to use a _predict_ sweep
 
-      /**
-       * @copydoc MLSDC::perform_sweeps()
-       */
-      virtual void perform_sweeps(size_t level) override;
+      void perform_sweeps(size_t level);
 
     public:
       /**
@@ -42,22 +39,22 @@ namespace pfasst
       /**
        * @copydoc MLSDC::cycle_down()
        */
-      virtual LevelIter cycle_down(LevelIter level_iter) override;
+      LevelIter cycle_down(LevelIter level_iter);
 
       /**
        * @copydoc MLSDC::cycle_up()
        */
-      virtual LevelIter cycle_up(LevelIter level_iter) override;
+      LevelIter cycle_up(LevelIter level_iter);
 
       /**
        * @copydoc MLSDC::cycle_bottom()
        */
-      virtual LevelIter cycle_bottom(LevelIter level_iter) override;
+      LevelIter cycle_bottom(LevelIter level_iter);
 
       /**
        * @copydoc MLSDC::cycle_v()
        */
-      virtual LevelIter cycle_v(LevelIter level_iter) override;
+      LevelIter cycle_v(LevelIter level_iter);
 
       /**
        * Predictor: restrict initial down, preform coarse sweeps, return to finest.

--- a/src/pfasst/controller/mlsdc_impl.hpp
+++ b/src/pfasst/controller/mlsdc_impl.hpp
@@ -152,7 +152,7 @@ namespace pfasst
    * @note This method is recursive with two exit points.
    *   The two exit points:
    *     1. if @p level_iter points to the coarsest level
-   *     2. if MLSDC::cycle_bottom() results in a converged state
+   *     2. if MLSDC::cycle_down() results in a converged state
    */
   template<typename time>
   typename MLSDC<time>::LevelIter MLSDC<time>::cycle_v(typename MLSDC<time>::LevelIter level_iter)


### PR DESCRIPTION
This makes MLSDC and PFASST match exactly when PFASST is used with only one processor.

Note that if you want to compare a particular example, make sure you are comparing apples to apples: number of levels, number of sweeps, quadrature etc etc must be exactly the same.
