### PR TITLE
cmake: juqueen: CMake's find_program sucks :-/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,14 @@ message(STATUS "****************************************************************
 message(STATUS "Configuring sources")
 update_site_config()
 
-find_package(PythonInterp REQUIRED)
+if(NOT PYTHON_EXECUTABLE)
+    find_package(PythonInterp 2.7)
+    if(NOT PYTHONINTERP_FOUND)
+        find_package(PythonInterp 3 REQUIRED)
+    endif()
+else()
+    message(STATUS "Using specified Python executable: ${PYTHON_EXECUTABLE}")
+endif()
 add_custom_target(set_version ALL
     COMMAND ${PYTHON_EXECUTABLE} ${pfasst_SOURCE_DIR}/tools/get_pfasst_version.py
     WORKING_DIRECTORY ${pfasst_SOURCE_DIR}

--- a/cmake/toolchain_juqueen.cmake
+++ b/cmake/toolchain_juqueen.cmake
@@ -7,6 +7,7 @@
 # Make sure you have loaded only the following modules:
 #  - gcc/4.8.1
 #  - fftw3/3.3.3
+#  - python3/3.4.2
 #
 # As well make sure you have built boost::program_options according to the instructions from the
 # PFASST++ documentation on JUQUEEN.
@@ -22,3 +23,5 @@ set(MPI_ROOT /bgsys/local/gcc/4.8.1)
 set(MPI_C_COMPILER ${MPI_ROOT}/bin/mpigcc)
 set(MPI_CXX_COMPILER ${MPI_ROOT}/bin/mpig++)
 set(MPI_Fortran_COMPILER ${MPI_ROOT}/bin/mpigfortran)
+
+set(PYTHON_EXECUTABLE /bgsys/local/python3/3.4.2/bin/python3)


### PR DESCRIPTION
Somehow it is not sufficient to just load the module (which extends the environment variable `PATH`) or to specify `CMAKE_PROGRAM_PATH` or `CMAKE_PREFIX_PATH` to include `/bgsys/local/python3/3.4.2[/bin]`.

With this dirty hack it should be possible to either let CMake search for a Python executable or specify `PYTHON_EXECUTABLE=<path-to-exe>` on calling CMake (or in the toolchain file).