### PR TITLE
cleanup some CMake stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,16 @@ set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/3rdparty)
 option(pfasst_DISABLE_LIBCXX    "Disable use of LLVM's libc++ when compiling with Clang." ON )
 option(pfasst_BUILD_SHARED_LIBS "Build shared libraries."                                 ON )
 option(pfasst_BUILD_EXAMPLES    "Build example programs."                                 ON )
-CMAKE_DEPENDENT_OPTION(pfasst_INSTALL_EXAMPLES "Install example programs." ON
-    "pfasst_BUILD_EXAMPLES" OFF)
+cmake_dependent_option(
+       pfasst_INSTALL_EXAMPLES  "Install example programs."                               ON
+           "pfasst_BUILD_EXAMPLES" OFF)
 option(pfasst_BUILD_TESTS       "Build test suite for PFASST."                            ON )
 option(pfasst_WITH_MPI          "Build with MPI enabled."                                 ON )
 option(pfasst_WITH_GCC_PROF     "Enable excessive debugging & profiling output with GCC." OFF)
 option(pfasst_DEFAULT_RAND_SEED "Using a hardcoded random seed"                           ON )
+cmake_dependent_option(
+       enable_LTO               "enable LinkTimeOptimization"                             OFF
+           "CMAKE_BUILD_TYPE" Release)
 
 if(${pfasst_WITH_MPI})
     find_package(MPI REQUIRED)
@@ -54,6 +58,12 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     if(pfasst_WITH_GCC_PROF)
         add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-ggdb3 -pg")
     endif(pfasst_WITH_GCC_PROF)
+    if(${CMAKE_BUILD_TYPE} MATCHES "Release" AND ${enable_LTO})
+        message(STATUS "enabling Link Time Optimization (LTO)")
+        set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -flto -fwhole-program")
+        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -flto")
+        set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} -flto")
+    endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     check_cxx_compiler_flag(-std=c++11 HAVE_STD11)
     if(HAVE_STD11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ cmake_dependent_option(
 option(pfasst_BUILD_TESTS       "Build test suite for PFASST."                            ON )
 option(pfasst_WITH_MPI          "Build with MPI enabled."                                 ON )
 option(pfasst_WITH_GCC_PROF     "Enable excessive debugging & profiling output with GCC." OFF)
-option(pfasst_DEFAULT_RAND_SEED "Using a hardcoded random seed"                           ON )
 cmake_dependent_option(
        enable_LTO               "enable LinkTimeOptimization"                             OFF
            "CMAKE_BUILD_TYPE" Release)
@@ -41,10 +40,6 @@ if(${pfasst_WITH_MPI})
     message(STATUS "Using MPI C++ Compiler Wrapper: ${MPI_CXX_COMPILER}")
     message(STATUS "USing MPI C Compiler Wrapper: ${MPI_C_COMPILER}")
     add_definitions(-DWITH_MPI)
-endif()
-
-if(pfasst_DEFAULT_RAND_SEED)
-    set(pfasst_RANDOM_SEED "42")
 endif()
 
 # Check for C++11 support
@@ -127,12 +122,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     add_feature_info(Profiling
         pfasst_WITH_GCC_PROF
         "build-in profiling support"
-    )
-endif()
-if(pfasst_RANDOM_SEED)
-    add_feature_info(DefaultRandomSeed
-        pfasst_RANDOM_SEED
-        "using specific default random seed ${pfasst_RANDOM_SEED}"
     )
 endif()
 

--- a/cmake/site_config.hpp.in
+++ b/cmake/site_config.hpp.in
@@ -3,10 +3,6 @@
 #ifndef _PFASST__SITE_CONFIG_HPP
 #define _PFASST__SITE_CONFIG_HPP
 
-#ifdef PFASST_DEFAULT_RANDOM_SEED
-  #define PFASST_RANDOM_SEED @pfasst_RANDOM_SEED@
-#endif
-
 #include <string>
 using namespace std;
 

--- a/doc/source/installing.md
+++ b/doc/source/installing.md
@@ -85,11 +85,6 @@ latest release from [GitHub][github_releases].
        `-Dpfasst_DISABLE_LIBCXX=OFF`.
        As libc++ is highly experimental on non-Darwin systems, this is a very exotic option.
 
-     * There are places in the code (mainly examples) that need a random number generator (RNG).
-       By default, `-Dpfasst_DEFAULT_RAND_SEED=ON` is set and the seed for the RNGs is set to `42`.
-       To overwrite this behaviour, set `-Dpfasst_DEFAULT_RAND_SEED=OFF` and 
-       `-Dpfasst_RANDOM_SEED=<YOUR_VALUE>`.
-
    * __Dependencies__
 
      * __Boost__

--- a/examples/boris/particle_cloud_impl.hpp
+++ b/examples/boris/particle_cloud_impl.hpp
@@ -18,6 +18,8 @@ using namespace std;
 
 #include "particle_util.hpp"
 
+#define PFASST_RANDOM_SEED 42
+
 
 namespace pfasst
 {
@@ -280,11 +282,7 @@ namespace pfasst
 
         precision scale = 1000.0;
 
-        #ifdef PFASST_DEFAULT_RANDOM_SEED
-          default_random_engine rd_gen(PFASST_RANDOM_SEED);
-        #else
-          default_random_engine rd_gen();
-        #endif
+        default_random_engine rd_gen(PFASST_RANDOM_SEED);
         precision max_pos = max(center->pos());
         precision max_vel = max(center->vel());
         uniform_real_distribution<precision> dist_pos(- max_pos / scale, max_pos / scale);


### PR DESCRIPTION
Adding a CMake option to enable Link-Time-Optimization (LTO) with GCC. Off by default.

This also fixes #208.