### PR TITLE
support for extra compiler wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ option(pfasst_WITH_GCC_PROF     "Enable excessive debugging & profiling output w
 cmake_dependent_option(
        enable_LTO               "enable LinkTimeOptimization"                             OFF
            "CMAKE_BUILD_TYPE" Release)
+cmake_dependent_option(
+       pfasst_WITH_SCOREP       "enable scalable instrumentation with Score-P"            OFF
+           "pfasst_WITH_MPI" ON)
 
 set(3rdparty_INCLUDES)
 set(3rdparty_DEPENDEND_LIBS)
@@ -35,6 +38,9 @@ set(pfasst_INCLUDES)
 set(pfasst_DEPENDEND_LIBS)
 set(pfasst_DEPENDEND_TARGETS)
 set(pfasst_TESTS_DEPENDEND_TARGETS)
+option(pfasst_WITH_EXTRA_WRAPPER "Build script to allow to set an additional wrapper via $PREP" OFF)
+
+option(pfasst_WITH_LOGGING      "Enable logging output on console"                        ON)
 
 message(STATUS "********************************************************************************")
 message(STATUS "Further tests on the compiler")
@@ -61,13 +67,19 @@ if(${pfasst_WITH_MPI})
     endif()
     message(STATUS "Using MPI C++ Compiler Wrapper: ${MPI_CXX_COMPILER}")
     add_definitions(-DWITH_MPI)
+endif()
 
-    if(${pfasst_WITH_MPIP})
-        message(STATUS "")
-        message(STATUS "Trying to find and link against mpiP")
-        find_package(MPIP REQUIRED)
-        list(APPEND pfasst_DEPENDEND_LIBS ${MPIP_LIBRARIES})
-    endif()
+if(pfasst_WITH_EXTRA_WRAPPER)
+    configure_file(
+        "${pfasst_SOURCE_DIR}/cmake/cxx_wrapper.sh.in"
+        "${CMAKE_BINARY_DIR}/cxx_wrapper.sh"
+    )
+    configure_file(
+        "${pfasst_SOURCE_DIR}/cmake/cc_wrapper.sh.in"
+        "${CMAKE_BINARY_DIR}/cc_wrapper.sh"
+    )
+    set(CMAKE_CXX_COMPILER "${CMAKE_BINARY_DIR}/cxx_wrapper.sh")
+    set(CMAKE_C_COMPILER "${CMAKE_BINARY_DIR}/cc_wrapper.sh")
 endif()
 
 # Check for C++11 support

--- a/cmake/cc_wrapper.sh.in
+++ b/cmake/cc_wrapper.sh.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+C_COMPILER=@CMAKE_C_COMPILER@
+
+$PREP $C_COMPILER $@

--- a/cmake/cxx_wrapper.sh.in
+++ b/cmake/cxx_wrapper.sh.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+CXX_COMPILER=@CMAKE_CXX_COMPILER@
+
+$PREP $CXX_COMPILER $@

--- a/doc/source/installing.md
+++ b/doc/source/installing.md
@@ -159,6 +159,10 @@ latest release from [GitHub][github_releases].
 There are a few tweaks and special care require to get up and running on supercomputers.
 We have compiled a few working walk-throughs at \subpage page_supercomputers .
 
+### Score-P and other compiler wrappers
+
+It is possible to use extra compiler wrappers like Score-P when compiling. See \subpage page_scorep.
+
 ## Building with vanilla make
 
 A sample `Makefile` is included in the `advection_diffusion` example.  This may be of particular

--- a/doc/source/scorep.md
+++ b/doc/source/scorep.md
@@ -1,0 +1,9 @@
+# Instrumentation with Score-P and usage of extra compiler wrappers           {#page_scorep}
+
+The _CMake_ build system of _PFASST++_ offers the option `pfasst_WITH_EXTRA_WRAPPER` that if enabled will create to shell scripts called `cc_wrapper.sh` and `cxx_wrapper.sh` in the build directory.These can be used to specify a compiler wrapper. Therefore the environment variable `PREP` is used. All compiler calls of the build system will result in calls to `$PREP <original-compiler>`. This will be demonstrated with the example of Score-P a scalable performance and communication analysis tool.
+
+1. Call cmake as usual but pass the argument `-Dpfasst_WITH_EXTRA_WRAPPER=ON` option. There should now be two shell scripts in the build directory.
+
+2. When compiling use `PREP=scorep make` instead of `make` otherwise you will compile as usual. The binaries are now instrumented using Score-P.
+
+Note on linking: On some architectures you only want to add Score-P during the link step. Therefore first compile without setting `PREP` which will result in an unistrumented object and binary. Than delete the binary and compile with `PREP=scorep`. Because the object files have not been deleted only the binaries will be linked (now with Score-P support).


### PR DESCRIPTION
Backporting work by @f-koehler to support extra compiler wrappers -- e.g. ScoreP -- during compiling and/or linking step via custom invocation script.

The added documentation should be clear enough.
