### PR TITLE
[WIP] Remove dependence on boost::program_options.

### DIFF
--- a/examples/advection_diffusion/Makefile
+++ b/examples/advection_diffusion/Makefile
@@ -1,9 +1,10 @@
 PFASST   := $(abspath ../..)
 STACK    ?= $(PFASST)/stack
 CXX      := $(STACK)/bin/mpic++
-CXXFLAGS ?= -std=c++11 -I$(PFASST)/include -I$(STACK)/include -I$(STACK)/include/eigen3
+CXXFLAGS ?= -std=c++11 -I$(PFASST)/include -I$(PFASST)/src -I$(STACK)/include -I$(STACK)/include/eigen3
 
-LDFLAGS  ?= -L$(STACK)/lib -Wl,-rpath=$(STACK)/lib -lboost_program_options -lfftw3
+#LDFLAGS  ?= -L$(STACK)/lib -Wl,-rpath=$(STACK)/lib -lboost_program_options -lfftw3
+LDFLAGS  ?= -L$(STACK)/lib -Wl,-rpath=$(STACK)/lib -lfftw3
 
 all: vanilla_sdc mpi_pfasst serial_mlsdc
 

--- a/examples/advection_diffusion/advection_diffusion_sweeper.hpp
+++ b/examples/advection_diffusion/advection_diffusion_sweeper.hpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <map>
 #include <ostream>
+#include <iomanip>
 #include <vector>
 #include <utility>
 using namespace std;
@@ -81,7 +82,7 @@ namespace pfasst
         public:
           static void init_opts()
           {
-            pfasst::config::options::add_option<size_t>("Adv/Diff Sweeper", "spatial_dofs", "Number of spatial degrees of freedom");
+            pfasst::config::options::add_option("Adv/Diff Sweeper", "spatial_dofs", "Number of spatial degrees of freedom");
           }
 
           static void init_logs()
@@ -166,6 +167,14 @@ namespace pfasst
 
             auto n = this->get_controller()->get_step();
             auto k = this->get_controller()->get_iteration();
+
+            //CLOG(INFO, "Advec")
+            // cout 
+            //   << "step: " << setw(4) << n
+            //   << ", iter: " << setw(2) << k
+            //   << ", nodes: " << setw(2) << this->get_nodes().size()
+            //   << ", dofs: " << setw(4) << qex.size()
+            //   << ", error: " << max << endl;
 
             this->errors.insert(vtype(ktype(n, k), max));
           }

--- a/examples/advection_diffusion/vanilla_sdc.cpp
+++ b/examples/advection_diffusion/vanilla_sdc.cpp
@@ -7,6 +7,7 @@
  */
 #include <cstdlib>
 #include <memory>
+#include <iostream>
 
 #include <fftw3.h>
 
@@ -37,10 +38,10 @@ namespace pfasst
 
         auto const nnodes = config::get_value<size_t>("num_nodes", 3);
         auto const ndofs  = config::get_value<size_t>("spatial_dofs", 64);
-        auto const quad_type = \
-          config::get_value<quadrature::QuadratureType>("nodes_type", quadrature::QuadratureType::GaussLegendre);
+        // auto const quad_type = \
+        //   config::get_value<quadrature::QuadratureType>("nodes_type", quadrature::QuadratureType::GaussLegendre);
 
-        auto quad    = quadrature::quadrature_factory(nnodes, quad_type);
+        auto quad    = quadrature::quadrature_factory(nnodes, quadrature::QuadratureType::GaussLegendre);
         auto factory = make_shared<encap::VectorFactory<double>>(ndofs);
         auto sweeper = make_shared<AdvectionDiffusionSweeper<>>(ndofs);
 

--- a/include/pfasst/logging.hpp
+++ b/include/pfasst/logging.hpp
@@ -256,8 +256,12 @@ namespace pfasst
                                          el::ConfigurationType::ToStandardOutput)->value();
       } else {
         milliseconds_width = PFASST_LOGGER_DEFAULT_GLOBAL_MILLISECOND_WIDTH;
-        to_stdout = (pfasst::config::options::get_instance().get_variables_map()
-                                                            .count("quiet")) ? "false" : "true";
+        auto bool_to_stdout = config::get_value<bool>("quiet", true);
+        if (bool_to_stdout) {
+          to_stdout = "true";
+        } else {
+          to_stdout = "false";
+        }
       }
 
       conf->setGlobally(el::ConfigurationType::ToStandardOutput, to_stdout);
@@ -297,8 +301,7 @@ namespace pfasst
      */
     inline static void add_custom_logger(const string& id)
     {
-      bool colorize = pfasst::config::options::get_instance().get_variables_map()
-                                                             .count("nocolor") ? false : true;
+      bool colorize = config::get_value<bool>("nocolor", true);
 
       const string INFO_COLOR = (colorize) ? OUT::blue : "";
       const string DEBG_COLOR = (colorize) ? "" : "";


### PR DESCRIPTION
This is a dumbed down option parser that doesn't require `boost::program_options`.

A few known issues:
- Help message and "groups" aren't really supported yet but this could be fixed without too much effort.
- Uses a stupid `string_as` function, but we could do better (use `boost::lexical_cast`, which is header only)
- Doesn't handle quadrature types yet.
- Doesn't support option files anymore (did anyone ever use this?).
- Doesn't handle aliases anymore (personallly, I don't think it's worth the effort)

Two pros:
- Removes redundancy of doubly specified argument types.
- NO MORE `boost::program_options`

Easy things to fix:
- We could strip out any '--' or '-' from the command line options before parsing them.  Currently you have to use the _exact_ form of the argument on the command line (ie, `num_nodes` instead of `--num_nodes`). 

(This PR doesn't merge cleanly but I will rebase if there is sufficient interest.)

@torbjoernk @pancetta What do you think?
