### PR TITLE
allow automatic build of dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,14 @@
 travis_deploy_rsa
 d[0-9a-f]/
 search/
+cxx_wrapper.sh
+cc_wrapper.sh
+
+3rdparty/Boost
+3rdparty/Eigen3
+3rdparty/fftw3
+3rdparty/gtest
+3rdparty/gmock
 
 .python-version
 __pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ addons:
       - boost-latest
       - ubuntu-toolchain-r-test
       - llvm-toolchain-precise-3.6
+      - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
     packages:
       - clang-3.6
+      - cmake
+      - cmake-data
       - doxygen
       - gcc-5
       - g++-5

--- a/3rdparty/Boost.cmake
+++ b/3rdparty/Boost.cmake
@@ -1,0 +1,134 @@
+set(Boost_COMPONENTS "program_options")
+
+if(pfasst_SYSTEM_BOOST)
+    message(STATUS "trying to use system's Boost")
+    set(Boost_USE_MULTITHREADED ON)
+
+    find_package(Boost 1.53.0 QUIET COMPONENTS ${Boost_COMPONENTS} REQUIRED)
+
+    message(STATUS "  found version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+    message(STATUS "  include path: ${Boost_INCLUDE_DIRS}")
+    message(STATUS "  library path: ${Boost_LIBRARY_DIRS}")
+else()
+    set(Boost_SOURCE_NAME "boost_1_60_0.tar.bz2")
+    set(Boost_SOURCE_MD5 "65a840e1a0b13a558ff19eeb2c4f0cbe")
+    message(STATUS "  using version: 1.60.0  (file: ${Boost_SOURCE_NAME})")
+
+    if(NOT Boost_SOURCES)
+        set(Boost_SOURCE_LOCATION "https://downloads.sourceforge.net/project/boost/boost/1.60.0")
+        message(STATUS "  going to download from: ${Boost_SOURCE_LOCATION}")
+        message(STATUS "    HINT: specify -DBoost_SOURCES=/local/directory/with/${Boost_SOURCE_NAME} to avoid redownloading")
+    else()
+        set(Boost_SOURCE_LOCATION ${Boost_SOURCES})
+        message(STATUS "  using pre-downloaded sources at: ${Boost_SOURCE_LOCATION}")
+    endif()
+
+    set(Boost_PREFIX "${3rdparty_PREFIX}/Boost")
+    set(Boost_TMP_PREFIX "${3rdparty_TMP_PREFIX}/Boost")
+
+    set(Boost_TMP_DIR "${Boost_TMP_PREFIX}/tmp")
+    set(Boost_STAMP_DIR "${Boost_TMP_PREFIX}/stamp")
+    set(Boost_DOWNLOAD_DIR "${Boost_PREFIX}/download")
+    set(Boost_SOURCE_DIR "${Boost_PREFIX}/src")
+    set(Boost_BINARY_DIR "${Boost_TMP_PREFIX}/build")
+    set(Boost_INSTALL_DIR "${Boost_PREFIX}/install")
+
+    set(Boost_build_CMD "${Boost_SOURCE_DIR}/bootstrap.sh")
+    list(APPEND Boost_build_CMD
+            --prefix=${Boost_INSTALL_DIR}
+            --with-libraries=${Boost_COMPONENTS}
+            )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+        list(APPEND Boost_build_CMD toolset=clang)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        list(APPEND Boost_build_CMD toolset=gcc)
+    endif()
+
+    ExternalProject_Add(boost_build
+        LIST_SEPARATOR " "
+        TMP_DIR "${Boost_TMP_DIR}"
+        STAMP_DIR "${Boost_STAMP_DIR}"
+        DOWNLOAD_DIR "${Boost_DOWNLOAD_DIR}"
+        SOURCE_DIR "${Boost_SOURCE_DIR}"
+        # BINARY_DIR "${Boost_BINARY_DIR}"  # not used as in-source build is specified
+        INSTALL_DIR "${Boost_INSTALL_DIR}"
+
+        EXCLUDE_FROM_ALL ON
+
+        URL ${Boost_SOURCE_LOCATION}/${Boost_SOURCE_NAME}
+        URL_MD5 ${Boost_SOURCE_MD5}
+        TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
+
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        BUILD_IN_SOURCE ON
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${Boost_build_CMD}
+        TEST_COMMAND ""
+        INSTALL_COMMAND ""
+
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+    )
+
+    set(Boost_LIBRARIES)
+    set(Boost_INCLUDE_DIRS ${Boost_SOURCE_DIR})
+    set(Boost_LIBRARY_DIR ${Boost_SOURCE_DIR}/stage/lib)
+
+    message(STATUS "  using components:")
+    foreach(component ${Boost_COMPONENTS})
+        message(STATUS "    ${component}")
+
+        set(Boost_${component}_BUILD_CMD ${Boost_SOURCE_DIR}/b2)
+        list(APPEND Boost_${component}_BUILD_CMD
+            --build-dir=${Boost_BINARY_DIR}
+            --with-${component}
+            address-model=64
+            cxxflags=-std=c++11
+            cxxflags=-fPIC
+            link=static
+            threading=multi
+            runtime-link=shared
+            variant=release
+        )
+        if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+            list(APPEND Boost_${component}_BUILD_CMD toolset=clang)
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            list(APPEND Boost_${component}_BUILD_CMD toolset=gcc)
+        endif()
+
+        ExternalProject_Add(boost_${component}
+            LIST_SEPARATOR " "
+            TMP_DIR "${Boost_TMP_DIR}"
+            STAMP_DIR "${Boost_STAMP_DIR}"
+            DOWNLOAD_DIR "${Boost_DOWNLOAD_DIR}"
+            SOURCE_DIR "${Boost_SOURCE_DIR}"
+            # BINARY_DIR "${Boost_BINARY_DIR}"  # not used as in-source build is specified
+            INSTALL_DIR "${Boost_INSTALL_DIR}"
+
+            EXCLUDE_FROM_ALL ON
+            DEPENDS boost_build
+
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PATCH_COMMAND ""
+            BUILD_IN_SOURCE ON
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ${Boost_${component}_BUILD_CMD} -j4 stage
+            TEST_COMMAND ""
+            INSTALL_COMMAND ""
+
+            LOG_DOWNLOAD ON
+            LOG_CONFIGURE ON
+            LOG_BUILD ON
+            LOG_INSTALL ON
+        )
+
+        list(APPEND pfasst_DEPENDEND_TARGETS boost_${component})
+        list(APPEND Boost_LIBRARIES ${Boost_LIBRARY_DIR}/libboost_${component}.a)
+    endforeach()
+
+    message(STATUS "  include path: ${Boost_INCLUDE_DIRS}")
+    message(STATUS "  library path: ${Boost_LIBRARY_DIR}")
+endif()

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -4,33 +4,58 @@ set(3rdparty_DEPENDEND_LIBS ${3rdparty_DEPENDEND_LIBS})
 set(pfasst_DEPENDEND_TARGETS ${pfasst_DEPENDEND_TARGETS})
 set(pfasst_TESTS_DEPENDEND_TARGETS ${pfasst_TESTS_DEPENDEND_TARGETS})
 
+if(3rdparty_SOURCES)
+    message(STATUS "trying to pick up pre-downloaded sources from: ${3rdparty_SOURCES}")
+    if(NOT Boost_SOURCES)
+        if(EXISTS ${3rdparty_SOURCES}/boost)
+            set(Boost_SOURCES ${3rdparty_SOURCES}/boost)
+        else()
+            message(STATUS "!! for Boost: <3rdparty_SOURCES>/boost does not exists")
+            message(STATUS "   use -DBoost_SOURCES=/local/path to overwrite <3rdparty_SOURCES>")
+        endif()
+    endif()
+    if(NOT Eigen3_SOURCES)
+        if(EXISTS ${3rdparty_SOURCES}/eigen3)
+            set(Eigen3_SOURCES ${3rdparty_SOURCES}/eigen3)
+        else()
+            message(STATUS "!! for Eigen3: <3rdparty_SOURCES>/eigen3 does not exists")
+            message(STATUS "   use -DEigen3_SOURCES=/local/path to overwrite <3rdparty_SOURCES>")
+        endif()
+    endif()
+    if(NOT fftw3_SOURCES)
+        if(EXISTS ${3rdparty_SOURCES}/fftw3)
+            set(fftw3_SOURCES ${3rdparty_SOURCES}/fftw3)
+        else()
+            message(STATUS "!! for FFTW3: <3rdparty_SOURCES>/fftw3 does not exists")
+            message(STATUS "   use -Dfftw3_SOURCES=/local/path to overwrite <3rdparty_SOURCES>")
+        endif()
+    endif()
+    if(NOT gtest_SOURCES)
+        if(EXISTS ${3rdparty_SOURCES}/gtest)
+            set(gtest_SOURCES ${3rdparty_SOURCES}/gtest)
+        else()
+            message(STATUS "!! for GTest: <3rdparty_SOURCES>/gtest does not exists")
+            message(STATUS "   use -Dgtest_SOURCES=/local/path to overwrite <3rdparty_SOURCES>")
+        endif()
+    endif()
+    if(NOT gmock_SOURCES)
+        if(EXISTS ${3rdparty_SOURCES}/gmock)
+            set(gmock_SOURCES ${3rdparty_SOURCES}/gmock)
+        else()
+            message(STATUS "!! for GMock: <3rdparty_SOURCES>/gmock does not exists")
+            message(STATUS "   use -Dgmock_SOURCES=/local/path to overwrite <3rdparty_SOURCES>")
+        endif()
+    endif()
+endif()
+
 set(3rdparty_DOWNLOAD_TIMEOUT "60")
+
 
 message(STATUS "--------------------------------------------------------------------------------")
 message(STATUS "Boost")
 
-set(Boost_USE_MULTITHREADED ON)
-if(${pfasst_BUILD_SHARED_LIBS})
-    set(Boost_USE_STATIC_LIBS OFF)
-else()
-    set(Boost_USE_STATIC_LIBS ON)
-endif()
-set(Boost_ADDITIONAL_VERSIONS "1.57" "1.57.0" ${Boost_ADDITIONAL_VERSIONS})
+include(Boost.cmake)
 
-if(${compiler_version_available} AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-    set(Boost_COMPILER "-clang${CMAKE_CXX_COMPILER_VERSION_MAJOR}${CMAKE_CXX_COMPILER_VERSION_MINOR}")
-endif()
-
-find_package(Boost 1.53.0 COMPONENTS program_options REQUIRED)
-set_package_properties(Boost
-    PROPERTIES
-      DESCRIPTION "C++ libraries"
-      URL "http://boost.org/"
-      TYPE REQUIRED
-      PURPOSE "command line parameter parsing"
-)
-message(STATUS "Boost include path: ${Boost_INCLUDE_DIRS}")
-message(STATUS "Boost library path: ${Boost_LIBRARY_DIRS}")
 list(APPEND 3rdparty_INCLUDES ${Boost_INCLUDE_DIRS})
 list(APPEND 3rdparty_DEPENDEND_LIBS ${Boost_LIBRARIES})
 
@@ -38,172 +63,31 @@ list(APPEND 3rdparty_DEPENDEND_LIBS ${Boost_LIBRARIES})
 message(STATUS "--------------------------------------------------------------------------------")
 message(STATUS "Eigen3")
 
-find_package(Eigen3)
-set_package_properties(Eigen3
-    PROPERTIES
-      DESCRIPTION "linear algebra library"
-      URL "http://eigen.tuxfamily.org/"
-      TYPE OPTIONAL
-      PURPOSE "matrix and vector types and arithmetics"
-)
-
-if(NOT EIGEN3_FOUND)
-    set(EIGEN3_SOURCE_URL "http://bitbucket.org/eigen/eigen/get/3.2.2.tar.bz2")
-    set(EIGEN3_SOURCE_MD5 "fc2e814ae449d16b331f7e1f4e272bd3")
-
-    message(STATUS "Eigen3 not found on your system")
-    message(STATUS " going to download sources from:")
-    message(STATUS "  ${EIGEN3_SOURCE_URL}")
-    set(Eigen3_SOURCE_DIR "${pfasst_BINARY_DIR}/3rdparty/src/Eigen3")
-
-    ExternalProject_Add(
-        Eigen3
-        LIST_SEPARATOR " "
-        URL ${EIGEN3_SOURCE_URL}
-        URL_MD5 ${EIGEN3_SOURCE_MD5}
-        TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
-        UPDATE_COMMAND ""
-        PATCH_COMMAND ""
-        BUILD_IN_SOURCE ON
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        TEST_COMMAND ""
-        INSTALL_DIR ""
-        INSTALL_COMMAND ""
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE OFF
-        LOG_BUILD OFF
-    )
-
-    # Specify include dir
-    set(Eigen3_INCLUDE_PATH "${Eigen3_SOURCE_DIR}")
-    set(Eigen3_FOUND TRUE)
-
-    list(APPEND pfasst_DEPENDEND_TARGETS Eigen3)
-
-    msg_not_installed("Eigen3")
-endif()
+include(Eigen3.cmake)
 
 list(APPEND 3rdparty_INCLUDES "${Eigen3_INCLUDE_PATH}")
 
 
-if(pfasst_BUILD_EXAMPLES)
-    message(STATUS "--------------------------------------------------------------------------------")
-    message(STATUS "FFTW3")
+message(STATUS "--------------------------------------------------------------------------------")
+message(STATUS "FFTW3")
 
-    find_package(FFTW)
-    set_package_properties(FFTW
-        PROPERTIES
-          DESCRIPTION "FFTW3"
-          URL "http://fftw.org/"
-          TYPE OPTIONAL
-          PURPOSE "fast Fourier transformation"
-    )
+include(FFTW3.cmake)
 
-    if(NOT FFTW_FOUND OR NOT FFTW_LIBRARIES)
-        set(FFTW3_SOURCE_URL "http://fftw.org/fftw-3.3.4.tar.gz")
-        set(FFTW3_SOURCE_MD5 "2edab8c06b24feeb3b82bbb3ebf3e7b3")
+set(FFTW3_LIBRARIES ${FFTW3_LIBRARIES} PARENT_SCOPE)
+set(FFTW3_INCLUDE_PATH ${FFTW3_INCLUDE_PATH} PARENT_SCOPE)
 
-        message(STATUS "FFTW3 not found on your system")
-        message(STATUS " going to download and compile it from sources retrieved from:")
-        message(STATUS "  ${FFTW3_SOURCE_URL}")
-        set(fftw3_SOURCE_DIR "${pfasst_BINARY_DIR}/3rdparty/src/fftw3")
-        set(fftw3_INSTALL_DIR "${pfasst_BINARY_DIR}/3rdparty/src/fftw3-install")
-
-        ExternalProject_Add(
-            fftw3
-            LIST_SEPARATOR " "
-            URL ${FFTW3_SOURCE_URL}
-            URL_MD5 ${FFTW3_SOURCE_MD5}
-            TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
-            UPDATE_COMMAND ""
-            PATCH_COMMAND ""
-            BUILD_IN_SOURCE ON
-            CONFIGURE_COMMAND ${fftw3_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} --prefix=${fftw3_INSTALL_DIR} --libdir=${fftw3_INSTALL_DIR}/lib
-            BUILD_COMMAND make
-            TEST_COMMAND ""
-            INSTALL_DIR ${fftw3_SOURCE_DIR}-install
-            INSTALL_COMMAND make install
-            LOG_DOWNLOAD ON
-            LOG_CONFIGURE ON
-            LOG_BUILD ON
-        )
-        # Specify include dir
-        set(FFTW_INCLUDE_PATH ${fftw3_INSTALL_DIR}/include)
-        set(FFTW_LIBRARIES ${fftw3_INSTALL_DIR}/lib/libfftw3.a)
-
-        set(FFTW_FOUND TRUE)
-
-        list(APPEND pfasst_DEPENDEND_LIBS FFTW)
-
-        msg_not_installed("FFTW3")
-    else()
-        set(FFTW_INCLUDE_PATH ${FFTW_INCLUDE_PATH} PARENT_SCOPE)
-        set(FFTW_LIBRARIES ${FFTW_LIBRARIES} PARENT_SCOPE)
-    endif()
-    set(FFTW_FOUND ${FFTW_FOUND} PARENT_SCOPE)
-endif()
 
 if(pfasst_BUILD_TESTS)
     set(TESTS_3rdparty_INCLUDES ${TESTS_3rdparty_INCLUDES})
     set(TESTS_3rdparty_DEPENDEND_LIBS ${TESTS_3rdparty_DEPENDEND_LIBS})
 
     message(STATUS "--------------------------------------------------------------------------------")
-    message(STATUS "Google Testing Framework (gtest & gmock)")
+    message(STATUS "Google Testing Framework")
 
-    find_package(GMock)
-    set_package_properties(GMock
-        PROPERTIES
-          DESCRIPTION "GMock"
-          URL "https://code.google.com/p/googlemock/"
-          TYPE OPTIONAL
-          PURPOSE "Google testing and mocking framework"
-    )
+    include(googletest.cmake)
 
-    if(NOT GMOCK_FOUND)
-        set(GMOCK_SOURCE_URL "http://googlemock.googlecode.com/files/gmock-1.7.0.zip")
-        set(GMOCK_SOURCE_MD5 "073b984d8798ea1594f5e44d85b20d66")
-
-        message(STATUS " going to download and compile it from sources retrieved from:")
-        message(STATUS "   ${GMOCK_SOURCE_URL}")
-
-        # Add gmock
-        ExternalProject_Add(
-          googlemock
-          URL ${GMOCK_SOURCE_URL}
-          URL_MD5 ${GMOCK_SOURCE_MD5}
-          TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
-          UPDATE_COMMAND ""
-          PATCH_COMMAND ""
-          CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_C_COMPILE=${CMAKE_C_COMPILER}
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-            -DGTEST_USE_OWN_TR1_TUPLE=ON
-            -Dgtest_force_shared_crt=ON
-            -Dgmock_build_tests=OFF
-          # Disable install step
-          INSTALL_COMMAND ""
-          # Wrap download, configure and build steps in a script to log output
-          LOG_DOWNLOAD ON
-          LOG_CONFIGURE ON
-          LOG_BUILD ON
-        )
-
-        # Specify include dir
-        ExternalProject_Get_Property(googlemock source_dir)
-        list(APPEND TESTS_3rdparty_INCLUDES ${source_dir}/include ${source_dir}/gtest/include)
-
-        ExternalProject_Get_Property(googlemock binary_dir)
-        set(Suffix ".a")
-        set(Pthread "-pthread")
-        list(APPEND TESTS_3rdparty_DEPENDEND_LIBS ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gmock${Suffix})
-        list(APPEND TESTS_3rdparty_DEPENDEND_LIBS ${Pthread})
-        list(APPEND pfasst_TESTS_DEPENDEND_TARGETS googlemock)
-    else()
-        list(APPEND TESTS_3rdparty_DEPENDEND_LIBS ${GMOCK_LIBRARIES} "-pthread")
-        list(APPEND TESTS_3rdparty_INCLUDES ${GMOCK_INCLUDE_DIRS})
-    endif(NOT GMOCK_FOUND)
+    list(APPEND TESTS_3rdparty_INCLUDES ${GOOGLETEST_INCLUDE_DIRS})
+    list(APPEND TESTS_3rdparty_DEPENDEND_LIBS gtest_lib gmock_lib ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 # propagate include lists to parent directory

--- a/3rdparty/Eigen3.cmake
+++ b/3rdparty/Eigen3.cmake
@@ -1,0 +1,67 @@
+if(pfasst_SYSTEM_BOOST)
+    message(STATUS "trying to use system's Eigen3")
+
+    find_package(Eigen3 QUIET REQUIRED)
+
+    message(STATUS "  include path: ${Eigen3_INCLUDE_PATH}")
+else()
+    set(Eigen3_SOURCE_NAME "3.2.5.tar.bz2")
+    set(Eigen3_SOURCE_MD5 "21a928f6e0f1c7f24b6f63ff823593f5")
+    message(STATUS "  using version: 3.2.5  (file: ${Eigen3_SOURCE_NAME})")
+
+    if(NOT Eigen3_SOURCES)
+        set(Eigen3_SOURCE_LOCATION "https://bitbucket.org/eigen/eigen/get")
+        message(STATUS "  going to download from: ${Eigen3_SOURCE_LOCATION}")
+        message(STATUS "    HINT: specify -DEigen3_SOURCES=/local/directory/with/${Eigen3_SOURCE_NAME} to avoid redownloading")
+    else()
+        set(Eigen3_SOURCE_LOCATION ${Eigen3_SOURCES})
+        message(STATUS "  using pre-downloaded sources at: ${Eigen3_SOURCE_LOCATION}")
+    endif()
+
+    set(Eigen3_PREFIX "${3rdparty_PREFIX}/Eigen3")
+    set(Eigen3_TMP_PREFIX "${3rdparty_TMP_PREFIX}/Eigen3")
+
+    set(Eigen3_TMP_DIR "${Eigen3_TMP_PREFIX}/tmp")
+    set(Eigen3_STAMP_DIR "${Eigen3_TMP_PREFIX}/stamp")
+    set(Eigen3_DOWNLOAD_DIR "${Eigen3_PREFIX}/download")
+    set(Eigen3_SOURCE_DIR "${Eigen3_PREFIX}/src")
+    set(Eigen3_BINARY_DIR "${Eigen3_TMP_PREFIX}/build")
+    set(Eigen3_INSTALL_DIR "${Eigen3_PREFIX}/install")
+
+    ExternalProject_Add(Eigen3
+        LIST_SEPARATOR " "
+        TMP_DIR "${Eigen3_TMP_DIR}"
+        STAMP_DIR "${Eigen3_STAMP_DIR}"
+        DOWNLOAD_DIR "${Eigen3_DOWNLOAD_DIR}"
+        SOURCE_DIR "${Eigen3_SOURCE_DIR}"
+        # BINARY_DIR "${Eigen3_BINARY_DIR}"  # not used as in-source build is specified
+        INSTALL_DIR "${Eigen3_INSTALL_DIR}"
+
+        EXCLUDE_FROM_ALL ON
+
+        URL ${Eigen3_SOURCE_LOCATION}/${Eigen3_SOURCE_NAME}
+        URL_MD5 ${Eigen3_SOURCE_MD5}
+        TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
+
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        BUILD_IN_SOURCE ON
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        TEST_COMMAND ""
+        INSTALL_COMMAND ""
+
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON
+    )
+
+    # Specify include dir
+    set(Eigen3_INCLUDE_PATH "${Eigen3_SOURCE_DIR}")
+    message(STATUS "  include path: ${Eigen3_INCLUDE_PATH}")
+
+    list(APPEND pfasst_DEPENDEND_TARGETS Eigen3)
+endif()
+
+set(Eigen3_INCLUDE_PATH ${Eigen3_INCLUDE_PATH} PARENT_SCOPE)

--- a/3rdparty/FFTW3.cmake
+++ b/3rdparty/FFTW3.cmake
@@ -1,0 +1,75 @@
+if(pfasst_SYSTEM_FFTW3)
+    message(STATUS "trying to use system's FFTW3")
+    find_package(FFTW QUIET REQUIRED)
+
+    message(STATUS "  include path: ${FFTW3_INCLUDE_PATH}")
+    message(STATUS "  libraries: ${FFTW3_LIBRARIES}")
+else()
+    set(fftw3_SOURCE_NAME "fftw-3.3.4.tar.gz")
+    set(fftw3_SOURCE_MD5 "2edab8c06b24feeb3b82bbb3ebf3e7b3")
+    message(STATUS "  using version: 3.3.4  (file: ${fftw3_SOURCE_NAME})")
+
+    if(NOT fftw3_SOURCES)
+        set(fftw3_SOURCE_LOCATION "http://www.fftw.org")
+        message(STATUS "  going to download from: ${fftw3_SOURCE_LOCATION}")
+        message(STATUS "    HINT: specify -Dfftw3_SOURCES=/local/directory/with/${fftw3_SOURCE_NAME} to avoid redownloading")
+    else()
+        set(fftw3_SOURCE_LOCATION ${fftw3_SOURCES})
+        message(STATUS "  using pre-downloaded sources at: ${fftw3_SOURCE_LOCATION}")
+    endif()
+
+    set(fftw3_PREFIX "${3rdparty_PREFIX}/fftw3")
+    set(fftw3_TMP_PREFIX "${3rdparty_TMP_PREFIX}/fftw3")
+
+    set(fftw3_TMP_DIR "${fftw3_TMP_PREFIX}/tmp")
+    set(fftw3_STAMP_DIR "${fftw3_TMP_PREFIX}/stamp")
+    set(fftw3_DOWNLOAD_DIR "${fftw3_PREFIX}/download")
+    set(fftw3_SOURCE_DIR "${fftw3_PREFIX}/src")
+    set(fftw3_BINARY_DIR "${fftw3_TMP_PREFIX}/build")
+    set(fftw3_INSTALL_DIR "${fftw3_PREFIX}/install")
+
+    ExternalProject_Add(fftw3
+        LIST_SEPARATOR " "
+        TMP_DIR "${fftw3_TMP_DIR}"
+        STAMP_DIR "${fftw3_STAMP_DIR}"
+        DOWNLOAD_DIR "${fftw3_DOWNLOAD_DIR}"
+        SOURCE_DIR "${fftw3_SOURCE_DIR}"
+        # BINARY_DIR "${fftw3_BINARY_DIR}"  # not used as in-source build is specified
+        INSTALL_DIR "${fftw3_INSTALL_DIR}"
+
+        EXCLUDE_FROM_ALL ON
+
+        URL ${fftw3_SOURCE_LOCATION}/${fftw3_SOURCE_NAME}
+        URL_MD5 ${fftw3_SOURCE_MD5}
+        TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
+
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        BUILD_IN_SOURCE ON
+        CONFIGURE_COMMAND ${fftw3_SOURCE_DIR}/configure
+            CC=${CMAKE_C_COMPILER}
+            CXX=${CMAKE_CXX_COMPILER}
+            CXXFLAGS=${CMAKE_CXX_FLAGS}
+            --prefix=${fftw3_INSTALL_DIR}
+            --libdir=${fftw3_INSTALL_DIR}/lib
+        BUILD_COMMAND make -j4
+        TEST_COMMAND ""
+        INSTALL_COMMAND make install
+
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON
+    )
+
+    set(FFTW3_INCLUDE_PATH ${fftw3_INSTALL_DIR}/include)
+    set(FFTW3_LIBRARY_DIR ${fftw3_INSTALL_DIR}/lib)
+    add_library(fftw3_lib STATIC IMPORTED GLOBAL)
+    set_property(TARGET fftw3_lib
+        PROPERTY IMPORTED_LOCATION ${FFTW3_LIBRARY_DIR}/libfftw3.a
+    )
+    add_dependencies(fftw3_lib fftw3)
+    set(FFTW3_LIBRARIES fftw3_lib)
+    message(STATUS "  include path: ${FFTW3_INCLUDE_PATH}")
+    message(STATUS "  library path: ${FFTW3_LIBRARY_DIR}")
+endif()

--- a/3rdparty/googletest.cmake
+++ b/3rdparty/googletest.cmake
@@ -1,0 +1,131 @@
+set(gtest_SOURCE_NAME "release-1.7.0.tar.gz")
+message(STATUS "  using version: 1.7.0  (file: ${gtest_SOURCE_NAME})")
+
+set(gtest_SOURCE_MD5 "4ff6353b2560df0afecfbda3b2763847")
+
+if(NOT gtest_SOURCES)
+    set(gtest_SOURCE_LOCATION "https://github.com/google/googletest/archive")
+    message(STATUS "  going to download from: ${gtest_SOURCE_LOCATION}")
+    message(STATUS "    HINT: specify -Dgtest_SOURCES=/local/directory/with/${gtest_SOURCE_NAME} to avoid redownloading")
+else()
+    set(gtest_SOURCE_LOCATION ${gtest_SOURCES})
+    message(STATUS "  using pre-downloaded sources at: ${gtest_SOURCE_LOCATION}")
+endif()
+
+
+set(gmock_SOURCE_NAME "release-1.7.0.tar.gz")
+set(gmock_SOURCE_MD5 "13c3b4a57ad575763deb73fc0ad96e07")
+
+if(NOT gmock_SOURCES)
+    set(gmock_SOURCE_LOCATION "https://github.com/google/googlemock/archive")
+    message(STATUS "  going to download from: ${gmock_SOURCE_LOCATION}")
+    message(STATUS "    HINT: specify -Dgmock_SOURCES=/local/directory/with/${gmock_SOURCE_NAME} to avoid redownloading")
+else()
+    set(gmock_SOURCE_LOCATION ${gmock_SOURCES})
+    message(STATUS "  using pre-downloaded sources at: ${gmock_SOURCE_LOCATION}")
+endif()
+
+set(gmock_PREFIX "${3rdparty_PREFIX}/gmock")
+set(gmock_TMP_PREFIX "${3rdparty_TMP_PREFIX}/gmock")
+
+set(gmock_TMP_DIR "${gmock_TMP_PREFIX}/tmp")
+set(gmock_STAMP_DIR "${gmock_TMP_PREFIX}/stamp")
+set(gmock_DOWNLOAD_DIR "${gmock_PREFIX}/download")
+set(gmock_SOURCE_DIR "${gmock_PREFIX}/src")
+set(gmock_BINARY_DIR "${gmock_TMP_PREFIX}/build")
+
+set(gtest_PREFIX "${3rdparty_PREFIX}/gtest")
+set(gtest_TMP_PREFIX "${3rdparty_TMP_PREFIX}/gtest")
+
+set(gtest_TMP_DIR "${gtest_TMP_PREFIX}/tmp")
+set(gtest_STAMP_DIR "${gtest_TMP_PREFIX}/stamp")
+set(gtest_DOWNLOAD_DIR "${gtest_PREFIX}/download")
+# gtest sources should be in a subdir of gmock sources
+set(gtest_SOURCE_DIR "${gmock_PREFIX}/gtest")
+# and gtest is build by gmock
+set(gtest_BINARY_DIR "${gmock_BINARY_DIR}/gtest")
+
+# Add gtest -- only download
+ExternalProject_Add(gtest
+    TMP_DIR "${gtest_TMP_DIR}"
+    STAMP_DIR "${gtest_STAMP_DIR}"
+    DOWNLOAD_DIR "${gtest_DOWNLOAD_DIR}"
+    SOURCE_DIR "${gtest_SOURCE_DIR}"
+    BINARY_DIR "${gtest_BINARY_DIR}"
+    INSTALL_DIR ""
+
+    EXCLUDE_FROM_ALL ON
+
+    URL ${gtest_SOURCE_LOCATION}/${gtest_SOURCE_NAME}
+    URL_MD5 ${gtest_SOURCE_MD5}
+    TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
+
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+
+    LOG_DOWNLOAD ON
+)
+
+# Add gmock
+ExternalProject_Add(gmock
+    TMP_DIR "${gmock_TMP_DIR}"
+    STAMP_DIR "${gmock_STAMP_DIR}"
+    DOWNLOAD_DIR "${gmock_DOWNLOAD_DIR}"
+    SOURCE_DIR "${gmock_SOURCE_DIR}"
+    BINARY_DIR "${gmock_BINARY_DIR}"
+    INSTALL_DIR ""
+
+    DEPENDS gtest
+    EXCLUDE_FROM_ALL ON
+
+    URL ${gmock_SOURCE_LOCATION}/${gmock_SOURCE_NAME}
+    URL_MD5 ${gmock_SOURCE_MD5}
+    TIMEOUT ${3rdparty_DOWNLOAD_TIMEOUT}
+
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILE=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        -Dgtest_USE_OWN_TR1_TUPLE=ON
+        -Dgtest_force_shared_crt=ON
+        -Dgtest_build_tests=OFF
+    BUILD_COMMAND make -j4
+    INSTALL_COMMAND ""
+
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+)
+
+set(gtest_INCLUDE_DIR ${gtest_SOURCE_DIR}/include)
+set(gtest_LIBRARY_DIR ${gtest_BINARY_DIR})
+set(gmock_INCLUDE_DIR ${gmock_SOURCE_DIR}/include)
+set(gmock_LIBRARY_DIR ${gmock_BINARY_DIR})
+
+add_library(gtest_lib STATIC IMPORTED GLOBAL)
+set_property(TARGET gtest_lib
+    PROPERTY IMPORTED_LOCATION ${gtest_LIBRARY_DIR}/libgtest.a
+)
+add_dependencies(gtest_lib gmock)
+
+add_library(gmock_lib STATIC IMPORTED GLOBAL)
+set_property(TARGET gmock_lib
+    PROPERTY IMPORTED_LOCATION ${gmock_LIBRARY_DIR}/libgmock.a
+)
+add_dependencies(gmock_lib gmock)
+
+message(STATUS "  include path: ${gtest_INCLUDE_DIR}")
+message(STATUS "  include path: ${gmock_INCLUDE_DIR}")
+message(STATUS "  library path: ${gtest_LIBRARY_DIR}")
+message(STATUS "  library path: ${gmock_LIBRARY_DIR}")
+
+set(GOOGLETEST_INCLUDE_DIRS ${gtest_INCLUDE_DIR} ${gmock_INCLUDE_DIR})
+set(GOOGLETEST_LIBRARY_DIRS ${gtest_LIBRARY_DIR} ${gmock_LIBRARY_DIR})
+
+set(CMAKE_THREAD_PREFER_PTHREAD)
+find_package(Threads QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.0)
 project(pfasst)
 
 list(APPEND CMAKE_MODULE_PATH ${pfasst_SOURCE_DIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,64 +8,55 @@ include(ExternalProject)
 include(CMakeDependentOption)
 include(FeatureSummary)
 
-# Set default ExternalProject root directory
-set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/3rdparty)
-
 list(APPEND CMAKE_FIND_ROOT_PATH ${pfasst_SOURCE_DIR}/stack)
 
+set(3rdparty_PREFIX "${CMAKE_SOURCE_DIR}/3rdparty")
+set(3rdparty_TMP_PREFIX "${CMAKE_BINARY_DIR}/3rdparty")
+# Set default ExternalProject root directory
+set_directory_properties(PROPERTIES EP_PREFIX "${3rdparty_PREFIX}")
+
+
 option(pfasst_DISABLE_LIBCXX    "Disable use of LLVM's libc++ when compiling with Clang." ON )
-option(pfasst_BUILD_SHARED_LIBS "Build shared libraries."                                 ON )
+option(BUILD_SHARED_LIBS        "Build shared libraries."                                 OFF)
+
 option(pfasst_BUILD_EXAMPLES    "Build example programs."                                 ON )
 cmake_dependent_option(
        pfasst_INSTALL_EXAMPLES  "Install example programs."                               ON
-           "pfasst_BUILD_EXAMPLES" OFF)
+            "pfasst_BUILD_EXAMPLES" OFF)
+
 option(pfasst_BUILD_TESTS       "Build test suite for PFASST."                            ON )
+
 option(pfasst_WITH_MPI          "Build with MPI enabled."                                 ON )
-cmake_dependent_option(
-       pfasst_WITH_MPIP         "enable to link against MPIP"                             OFF
-           "pfasst_WITH_MPI" ON)
+option(pfasst_SYSTEM_BOOST      "Use system's Boost library; fail if not found"           OFF)
+option(pfasst_SYSTEM_FFTW3      "Use system's FFTW library; fail if not found"            OFF)
+option(pfasst_SYSTEM_EIGEN3     "Use system's Eigen3 library; fail if not found"          OFF)
+
 option(pfasst_WITH_GCC_PROF     "Enable excessive debugging & profiling output with GCC." OFF)
 cmake_dependent_option(
        enable_LTO               "enable LinkTimeOptimization"                             OFF
-           "CMAKE_BUILD_TYPE" Release)
-cmake_dependent_option(
-       pfasst_WITH_SCOREP       "enable scalable instrumentation with Score-P"            OFF
-           "pfasst_WITH_MPI" ON)
+            "CMAKE_BUILD_TYPE" Release)
 
-set(3rdparty_INCLUDES)
-set(3rdparty_DEPENDEND_LIBS)
-set(pfasst_INCLUDES)
-set(pfasst_DEPENDEND_LIBS)
-set(pfasst_DEPENDEND_TARGETS)
-set(pfasst_TESTS_DEPENDEND_TARGETS)
 option(pfasst_WITH_EXTRA_WRAPPER "Build script to allow to set an additional wrapper via $PREP" OFF)
 
 option(pfasst_WITH_LOGGING      "Enable logging output on console"                        ON)
 
-message(STATUS "********************************************************************************")
-message(STATUS "Further tests on the compiler")
-if(${pfasst_BUILD_SHARED_LIBS})
-    message(STATUS "build dynamic libraries and shared linked executables")
-else()
-    message(STATUS "build static libraries and staticaly linked executables")
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-    set(BUILD_SHARED_LIBRARIES OFF)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+if(NOT ${pfasst_WITH_LOGGING})
+    add_definitions(-DPFASST_NO_LOGGING)
 endif()
-message(STATUS "")
 
 if(${pfasst_WITH_MPI})
-    message(STATUS "--------------------------------------------------------------------------------")
-    message(STATUS "Detecting MPI")
     find_package(MPI REQUIRED)
-    if(NOT "${CMAKE_CXX_COMPILER}" STREQUAL "${MPI_CXX_COMPILER}")
+    if(NOT "${CMAKE_CXX_COMPILER}" STREQUAL "${MPI_CXX_COMPILER}" OR
+       NOT "${CMAKE_C_COMPILER}" STREQUAL "${MPI_C_COMPILER}")
         message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
         message(STATUS "MPI C++ Compiler Wrapper: ${MPI_CXX_COMPILER}")
-        message(WARNING "Please make sure to set CXX to the MPI compiler wrappers!")
+        message(WARNING "Please make sure to set CXX and CC to the MPI compiler wrappers!")
         set(CMAKE_CXX_COMPILER "${MPI_CXX_COMPILER}")
+        set(CMAKE_C_COMPILER "${MPI_C_COMPILER}")
         message(STATUS "Set default compilers to MPI compilers.")
     endif()
     message(STATUS "Using MPI C++ Compiler Wrapper: ${MPI_CXX_COMPILER}")
+    message(STATUS "USing MPI C Compiler Wrapper: ${MPI_C_COMPILER}")
     add_definitions(-DWITH_MPI)
 endif()
 
@@ -83,8 +74,6 @@ if(pfasst_WITH_EXTRA_WRAPPER)
 endif()
 
 # Check for C++11 support
-message(STATUS "--------------------------------------------------------------------------------")
-message(STATUS "Checking C++11 standard support")
 if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     check_cxx_compiler_flag(-std=c++11 HAVE_STD11)
     if(HAVE_STD11)
@@ -92,11 +81,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     else()
         message(FATAL_ERROR "No advanced standard C++ support of your GCC (-std=c++11 not defined).")
     endif()
-    if(${CMAKE_BUILD_TYPE} MATCHES Debug)
-        add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-Og")
-    endif()
     if(pfasst_WITH_GCC_PROF)
-        message(STATUS "enabling profiling support")
         add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-ggdb3 -pg")
     endif(pfasst_WITH_GCC_PROF)
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" AND ${enable_LTO})
@@ -121,21 +106,20 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     else()
         message(FATAL_ERROR "No C++11 support for Clang version. Please upgrade Clang to a version supporting C++11.")
     endif()
-    add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-fdiagnostics-show-category=name -fdiagnostics-show-template-tree")
-elseif(${CMAKE_CXX_COMPILER_ID} MATCHES XL)
-    # NOTE: This branch is not tested yet (in theory it should work)
-    message(WARNING "IMB XL C/C++ support is experimental and not yet tested.")
-    check_cxx_compiler_flag(-qlanglvl=extended0x HAVE_STD11)
+    add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-Wdeprecated -fdiagnostics-show-category=name -fdiagnostics-show-template-tree")
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES Intel)
+    check_cxx_compiler_flag(-std=c++11 HAVE_STD11)
     if(HAVE_STD11)
-        add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-qlanglvl=extended0x -qwarn0x")
+        add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-std=c++11")
     else()
-        message(FATAL_ERROR "No advanced standard C++ support of your IBM XL C/C++ compiler (-qlanglvl=extended0x not defined).")
+        message(FATAL_ERROR "No advanced standard C++ support for your Intel compiler (-std=c++11 not defined).")
     endif()
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES XL)
+    message(FATAL_ERROR "IMB XL C/C++ does not support C++11 features PFASST++ is utilizing.")
 else()
     message(FATAL_ERROR "Don't know how to check C++11 compatibility with compiler '${CMAKE_CXX_COMPILER_ID}'")
 endif()
 message(STATUS "Your compiler has C++11 support. Hurray!")
-message(STATUS "")
 
 if(CMAKE_CXX_COMPILER_VERSION)
     string(REGEX MATCH "^[0-9]+" CMAKE_CXX_COMPILER_VERSION_MAJOR ${CMAKE_CXX_COMPILER_VERSION})
@@ -149,7 +133,9 @@ else()
 endif()
 
 # Enable all compiler warnings
-if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES Intel)
+    add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-Wall -Wextra")
+else()
     add_to_string_list("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
 endif()
 
@@ -174,6 +160,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
     )
 endif()
 
+set(3rdparty_INCLUDES)
+set(3rdparty_DEPENDEND_LIBS)
+set(pfasst_INCLUDES)
+set(pfasst_DEPENDEND_LIBS)
+set(pfasst_DEPENDEND_TARGETS)
+set(pfasst_TESTS_DEPENDEND_TARGETS)
+
 if(pfasst_BUILD_TESTS)
     enable_testing()
     set(TESTS_3rdparty_INCLUDES)
@@ -184,14 +177,13 @@ endif(pfasst_BUILD_TESTS)
 message(STATUS "********************************************************************************")
 message(STATUS "Configuring 3rd party libraries")
 # makes available:
-#  - Boost headers in 3rdparty_INCLUDES
-#  - Boost libraries in Boost_LIBRARY_DIRS
-#  - Eigen headers in 3rdparty_INCLUDES
-#  - Google test and mock headers in 3rdparty_INCLUDES (if pfasst_BUILD_TESTS)
-#  - FFTW_INCLUDE_PATH (if pfasst_BUILD_EXAMPLES)
-#  - FFTW_LIBRARIES (if pfasst_BUILD_EXAMPLES)
+#  - required headers in 3rdparty_INCLUDES
+#  - required libraries in 3rdparty_DEPENDEND_LIBS and pfasst_DEPENDEND_LIBS
+#  - Google test and mock headers in TESTS_3rdparty_INCLUDES (if pfasst_BUILD_TESTS)
+#  - Google test and mock libraries in TESTS_3rdparty_DEPENDEND_LIBS (if pfasst_BUILD_TESTS)
+#  - FFTW3_INCLUDE_PATH
+#  - FFTW3_LIBRARIES
 add_subdirectory(3rdparty)
-message(STATUS "")
 
 message(STATUS "********************************************************************************")
 message(STATUS "Configuring sources")
@@ -219,21 +211,18 @@ list(LENGTH pfasst_TESTS_DEPENDEND_TARGETS pfasst_TESTS_NUM_DEPENDEND_TARGETS)
 
 add_subdirectory(include)
 add_subdirectory(src)
-message(STATUS "")
 
 if(pfasst_BUILD_EXAMPLES)
     message(STATUS "********************************************************************************")
     message(STATUS "Configuring examples")
     set(examples_to_install)
     add_subdirectory(examples)
-    message(STATUS "")
 endif()
 
 if(pfasst_BUILD_TESTS)
     message(STATUS "********************************************************************************")
     message(STATUS "Configuring tests")
     add_subdirectory(tests)
-    message(STATUS "")
 endif()
 message(STATUS "********************************************************************************")
 
@@ -257,16 +246,15 @@ if(pfasst_BUILD_EXAMPLES AND pfasst_INSTALL_EXAMPLES)
         message(STATUS "      - ${example_program}")
     endforeach()
 endif()
-message(STATUS "")
 
 message(STATUS "********************************************************************************")
 if(${CMAKE_VERBOSE_MAKEFILE})
   message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
   message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+  message(STATUS "C++ Compiler Names: ${CMAKE_CXX_COMPILER_NAMES}")
   message(STATUS "C++ Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
   message(STATUS "C++ Flags: ${CMAKE_CXX_FLAGS}")
-  message(STATUS "C++ link flags: ${CMAKE_CXX_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
-  message(STATUS "Dependend Libs: ${pfasst_DEPENDEND_LIBS}")
+  message(STATUS "C++ link flags: ${CMAKE_CXX_LINK_FLAGS}")
   message(STATUS "********************************************************************************")
 endif()
 

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -11,8 +11,20 @@ endif(Eigen3_INCLUDE_PATH)
 
 find_path(Eigen3_INCLUDE_PATH
     signature_of_eigen3_matrix_library
+    HINTS
+        ${EIGEN3_ROOT}
+        ${EIGEN3_ROOT}/include
+        ${EIGEN3_INC}
+        ${EIGEN_ROOT}
+        ${EIGEN3_ROOT}/include
+        ${EIGEN_INC}
+        $ENV{EIGEN3_ROOT}
+        $ENV{EIGEN3_ROOT}/include
+        $ENV{EIGEN3_INC}
+        $ENV{EIGEN_ROOT}
+        $ENV{EIGEN3_ROOT}/include
+        $ENV{EIGEN_INC}
     PATH_SUFFIXES eigen3 Eigen3 Eigen
-    HINTS $ENV{EIGEN3_DIR}/include/eigen3 # Edison
 )
 
 # handle the QUIETLY and REQUIRED arguments and set FFTW_FOUND to TRUE if

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -10,29 +10,25 @@ if(FFTW_INCLUDE_PATH)
     set(FFTW_FIND_QUIETLY TRUE)
 endif(FFTW_INCLUDE_PATH)
 
-find_path(FFTW_INCLUDE_PATH fftw3.h
-    HINTS ${FFTW3_INCLUDE}
-        ${FFTW3_INC}
-        ${FFTW3_ROOT}/include
+find_path(FFTW3_INCLUDE_PATH fftw3.h
+    HINTS ${FFTW3_ROOT}
+        ${FFTW3_INCLUDE}
+        $ENV{FFTW3_ROOT}
         $ENV{FFTW3_INCLUDE}
-        $ENV{FFTW3_INC}
-        $ENV{FFTW_INC} # Edison
-        $ENV{FFTW3_ROOT}/include
 )
 
-find_library(FFTW_LIBRARIES NAMES fftw3 fftw3l fftw3_mpi fftw3l_mpi fftw3_omp fftw3l_omp
-    HINTS ${FFTW3_LIB}
-        ${FFTW3_ROOT}/lib64
-        ${FFTW3_ROOT}/lib
+find_library(FFTW3_LIBRARIES NAMES fftw3
+    HINTS ${FFTW3_ROOT}
+        ${FFTW3_LIB}
+        ${FFTW3_LIBS}
+        $ENV{FFTW3_ROOT}
         $ENV{FFTW3_LIB}
-        $ENV{FFTW_DIR} # Edison
-        $ENV{FFTW3_ROOT}/lib64
-        $ENV{FFTW3_ROOT}/lib
+        $ENV{FFTW3_LIBS}
 )
 
 # handle the QUIETLY and REQUIRED arguments and set FFTW_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FFTW DEFAULT_MSG FFTW_LIBRARIES FFTW_INCLUDE_PATH)
+find_package_handle_standard_args(FFTW DEFAULT_MSG FFTW3_LIBRARIES FFTW3_INCLUDE_PATH)
 
-mark_as_advanced(FFTW_LIBRARIES FFTW_INCLUDE_PATH)
+mark_as_advanced(FFTW3_LIBRARIES FFTW3_INCLUDE_PATH)

--- a/examples/advection_diffusion/CMakeLists.txt
+++ b/examples/advection_diffusion/CMakeLists.txt
@@ -3,8 +3,8 @@ set(examples_to_install ${examples_to_install})
 message(STATUS "  advection_diffusion")
 include_directories(
     ${3rdparty_INCLUDES}
-    ${FFTW_INCLUDE_PATH}
     ${pfasst_INCLUDES}
+    ${FFTW3_INCLUDE_PATH}
 )
 
 set(advec_examples
@@ -25,16 +25,11 @@ endif()
 
 foreach(example ${all_advec_examples})
     add_executable(${example} ${CMAKE_CURRENT_SOURCE_DIR}/${example}.cpp)
-    if(NOT FFTW_FOUND)
-        add_dependencies(${example} fftw3)
-    endif()
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
     target_link_libraries(${example}
         ${pfasst_DEPENDEND_LIBS}
         ${3rdparty_DEPENDEND_LIBS}
-        ${FFTW_LIBRARIES}
+        ${FFTW3_LIBRARIES}
     )
     if(pfasst_INSTALL_EXAMPLES)
         install(TARGETS ${example} RUNTIME DESTINATION bin)

--- a/examples/boris/CMakeLists.txt
+++ b/examples/boris/CMakeLists.txt
@@ -23,15 +23,12 @@ endif()
 
 foreach(example ${boris_examples})
     add_executable(${example} ${CMAKE_CURRENT_SOURCE_DIR}/${example}.cpp)
+    add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
     target_link_libraries(${example}
         ${pfasst_DEPENDEND_LIBS}
         ${3rdparty_DEPENDEND_LIBS}
         simple_physics_solver
     )
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    add_dependencies(${example} simple_physics_solver)
     if(pfasst_INSTALL_EXAMPLES)
         install(TARGETS ${example} RUNTIME DESTINATION bin)
     endif()

--- a/examples/scalar/CMakeLists.txt
+++ b/examples/scalar/CMakeLists.txt
@@ -12,9 +12,7 @@ set(scalar_examples
 
 foreach(example ${scalar_examples})
     add_executable(${example} ${CMAKE_CURRENT_SOURCE_DIR}/${example}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
     target_link_libraries(${example}
         ${pfasst_DEPENDEND_LIBS}
         ${3rdparty_DEPENDEND_LIBS}

--- a/examples/vanderpol/CMakeLists.txt
+++ b/examples/vanderpol/CMakeLists.txt
@@ -12,9 +12,7 @@ set(vanderpol_examples
 
 foreach(example ${vanderpol_examples})
     add_executable(${example} ${CMAKE_CURRENT_SOURCE_DIR}/${example}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${example} ${pfasst_DEPENDEND_TARGETS})
     target_link_libraries(${example}
         ${pfasst_DEPENDEND_LIBS}
         ${3rdparty_DEPENDEND_LIBS}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,12 +14,10 @@ set(TESTS
 foreach(test ${TESTS})
     message(STATUS "  ${test}")
     add_executable(${test} ${test}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${test}
+        ${pfasst_DEPENDEND_TARGETS}
+        ${pfasst_TESTS_DEPENDEND_TARGETS}
+    )
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
         ${TESTS_3rdparty_DEPENDEND_LIBS}

--- a/tests/examples/advection_diffusion/CMakeLists.txt
+++ b/tests/examples/advection_diffusion/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories(
     ${3rdparty_INCLUDES}
     ${TESTS_3rdparty_INCLUDES}
-    ${FFTW_INCLUDE_PATH}
+    ${FFTW3_INCLUDE_PATH}
     ${pfasst_INCLUDES}
 )
 
@@ -16,15 +16,10 @@ if(${pfasst_WITH_MPI})
     foreach(test ${MPI_TESTS})
         message(STATUS "  ${test}")
         add_executable(${test} ${test}.cpp)
-        if(NOT FFTW_FOUND)
-            add_dependencies(${test} fftw3)
-        endif()
-        if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-            add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-        endif()
-        if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-            add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-        endif()
+        add_dependencies(${test}
+            ${pfasst_DEPENDEND_TARGETS}
+            ${pfasst_TESTS_DEPENDEND_TARGETS}
+        )
         if(MPI_COMPILE_FLAGS)
             if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
                 set_target_properties(${test}
@@ -36,7 +31,7 @@ if(${pfasst_WITH_MPI})
         target_link_libraries(${test}
             ${3rdparty_DEPENDEND_LIBS}
             ${TESTS_3rdparty_DEPENDEND_LIBS}
-            ${FFTW_LIBRARIES}
+            ${FFTW3_LIBRARIES}
             ${pfasst_DEPENDEND_LIBS}
         )
         add_test(NAME ${test}
@@ -53,19 +48,14 @@ set(TESTS
 foreach(test ${TESTS})
     message(STATUS "  ${test}")
     add_executable(${test} ${test}.cpp)
-    if(NOT FFTW_FOUND)
-        add_dependencies(${test} fftw3)
-    endif()
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${test}
+        ${pfasst_DEPENDEND_TARGETS}
+        ${pfasst_TESTS_DEPENDEND_TARGETS}
+    )
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
         ${TESTS_3rdparty_DEPENDEND_LIBS}
-        ${FFTW_LIBRARIES}
+        ${FFTW3_LIBRARIES}
         ${pfasst_DEPENDEND_LIBS}
     )
     if(pfasst_WITH_GCC_PROF AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU)

--- a/tests/examples/boris/CMakeLists.txt
+++ b/tests/examples/boris/CMakeLists.txt
@@ -13,12 +13,10 @@ set(TESTS
 foreach(test ${TESTS})
     message(STATUS "  ${test}")
     add_executable(${test} ${test}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${test}
+        ${pfasst_DEPENDEND_TARGETS}
+        ${pfasst_TESTS_DEPENDEND_TARGETS}
+    )
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
         ${TESTS_3rdparty_DEPENDEND_LIBS}

--- a/tests/examples/scalar/CMakeLists.txt
+++ b/tests/examples/scalar/CMakeLists.txt
@@ -13,12 +13,10 @@ set(TESTS
 foreach(test ${TESTS})
     message(STATUS "  ${test}")
     add_executable(${test} ${test}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${test}
+        ${pfasst_DEPENDEND_TARGETS}
+        ${pfasst_TESTS_DEPENDEND_TARGETS}
+    )
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
         ${TESTS_3rdparty_DEPENDEND_LIBS}

--- a/tests/examples/vanderpol/CMakeLists.txt
+++ b/tests/examples/vanderpol/CMakeLists.txt
@@ -12,12 +12,10 @@ set(TESTS
 foreach(test ${TESTS})
     message(STATUS "  ${test}")
     add_executable(${test} ${test}.cpp)
-    if(${pfasst_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_DEPENDEND_TARGETS})
-    endif()
-    if(${pfasst_TESTS_NUM_DEPENDEND_TARGETS} GREATER 0)
-        add_dependencies(${test} ${pfasst_TESTS_DEPENDEND_TARGETS})
-    endif()
+    add_dependencies(${test}
+        ${pfasst_DEPENDEND_TARGETS}
+        ${pfasst_TESTS_DEPENDEND_TARGETS}
+    )
     target_link_libraries(${test}
         ${3rdparty_DEPENDEND_LIBS}
         ${TESTS_3rdparty_DEPENDEND_LIBS}


### PR DESCRIPTION
From now on, CMake will download, compile and use all dependencies of
PFASST++ itself. Namely boost::program_options, Eigen3, FFTW3 and
GoogleTest/GoogleMock.

To avoid redownloading the dependencies' sources, one can specify a
directory where CMake can find the sources.
The following is the expected structure of that path's tree:

```
$ tree /path/to/sources
/path/to/sources
|- boost
|  |- boost_1_60_0.tar.bz2
|- eigen3
|  |- 3.2.5.tar.bz2
|- fftw3
|  |- fftw-3.3.4.tar.gz
|- gmock
|  |- release-1.7.0.tar.gz
|- gtest
   |- release-1.7.0.tar.gz
```

The URLs for these files can be found by running CMake once (or by
looking into `3rdparty/*.cmake`).

To tell CMake to use these pre-downloaded sources, add
`-D3rdpart_SOURCES=/path/to/sources` to the invocation of CMake.

One can overwrite the default behaviour of downloading and compiling
Boost, FFTW3 and Eigen3 selectively by specifying the following on the
invocation of CMake:

```
-Dpfasst_SYSTEM_BOOST=ON
-Dpfasst_SYSTEM_FFTW3=ON
-Dpfasst_SYSTEM_EIGEN3=ON
```
